### PR TITLE
feat: add traverse function

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,16 @@
         "default": "./dist/index.cjs"
       }
     },
+    "./traverse": {
+      "import": {
+        "types": "./dist/traverse.d.ts",
+        "default": "./dist/traverse.mjs"
+      },
+      "require": {
+        "types": "./dist/traverse.d.cts",
+        "default": "./dist/traverse.cjs"
+      }
+    },
     "./package.json": "./package.json"
   },
   "main": "./dist/index.cjs",

--- a/src/traverse.ts
+++ b/src/traverse.ts
@@ -1,0 +1,49 @@
+import type { AutoIndexFormat, RootEntry } from "./";
+import { parse } from "./";
+
+export interface TraverseOptions {
+  /**
+   * Optional format specification of the auto-index page (will be inferred if not provided)
+   * @default undefined
+   */
+  format?: AutoIndexFormat;
+
+  /**
+   * Optional extra headers to include in the request
+   * @default {}
+   */
+  extraHeaders?: Record<string, string>;
+}
+
+export async function traverse(rootUrl: string, options?: TraverseOptions): Promise<RootEntry | null> {
+  const res = await fetch(rootUrl, {
+    headers: {
+      "User-Agent": "github.com/apache-autoindex-parse",
+      ...options?.extraHeaders,
+    },
+  });
+
+  if (!res.ok) {
+    throw new Error(`failed to fetch directory listing from ${rootUrl}`);
+  }
+
+  const html = await res.text();
+
+  const root = parse(html, options?.format);
+
+  // for each directory entry, fetch its children
+  for (const entry of root?.children ?? []) {
+    if (entry.type === "file") {
+      continue;
+    }
+
+    const childUrl = new URL(entry.path, rootUrl).href;
+    const child = await traverse(childUrl, options);
+
+    if (child == null) continue;
+
+    entry.children = child.children;
+  }
+
+  return root;
+}

--- a/src/traverse.ts
+++ b/src/traverse.ts
@@ -15,6 +15,22 @@ export interface TraverseOptions {
   extraHeaders?: Record<string, string>;
 }
 
+/**
+ * Recursively traverses an Apache autoindex directory structure.
+ *
+ * This function fetches the HTML content from the provided URL, parses it to extract directory entries,
+ * and then recursively traverses any subdirectories found.
+ *
+ * @param {string} rootUrl - The URL of the Apache autoindex directory to traverse
+ * @param {TraverseOptions?} options - Optional configuration for the traversal process
+ * @returns {Promise<RootEntry | null>} A promise that resolves to a RootEntry object representing the directory structure, or null if parsing failed
+ * @throws Will throw an error if the fetch request fails
+ *
+ * @example
+ * ```typescript
+ * const directoryStructure = await traverse('https://example.com/files/');
+ * ```
+ */
 export async function traverse(rootUrl: string, options?: TraverseOptions): Promise<RootEntry | null> {
   const res = await fetch(rootUrl, {
     headers: {

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,7 +1,10 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-  entry: ["./src/index.ts"],
+  entry: [
+    "./src/index.ts",
+    "./src/traverse.ts",
+  ],
   format: ["cjs", "esm"],
   clean: true,
   dts: true,


### PR DESCRIPTION
This PR adds a new traverse export that will make it possible to traverse an entire apache autoindex.

There is some optimizations that could be made in the `parse` call, but that will be improved in another pull request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced the module export to support both modern and legacy module systems, ensuring wider compatibility.
	- Introduced an asynchronous functionality that retrieves and processes directory listings with optional parameters.
	- Updated the build process to integrate additional entry points for improved bundling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->