### PR TITLE
feat!: remove root path from path

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -51,15 +51,15 @@ export function parse(html: string, format?: AutoIndexFormat): RootEntry | null 
   }
 
   if (format === "F0") {
-    entries = parseF0(html, rootPath);
+    entries = parseF0(html);
   }
 
   if (format === "F1") {
-    entries = parseF1(html, rootPath);
+    entries = parseF1(html);
   }
 
   if (format === "F2") {
-    entries = parseF2(html, rootPath);
+    entries = parseF2(html);
   }
 
   return {
@@ -99,7 +99,7 @@ function inferFormat(html: string): AutoIndexFormat {
   return "F0";
 }
 
-function parseF0(html: string, rootPath: string): Entry[] {
+function parseF0(html: string): Entry[] {
   const entries: Entry[] = [];
 
   // find the first ul element and its li children
@@ -123,9 +123,7 @@ function parseF0(html: string, rootPath: string): Entry[] {
       continue;
     }
 
-    const path = /^https?:\/\//.test(href)
-      ? href
-      : `${rootPath}/${href}`;
+    const path = href;
 
     if (isDirectory) {
       entries.push({
@@ -148,7 +146,7 @@ function parseF0(html: string, rootPath: string): Entry[] {
   return entries;
 }
 
-function parseF1(html: string, rootPath: string): Entry[] {
+function parseF1(html: string): Entry[] {
   const entries: Entry[] = [];
 
   // find all pre elements
@@ -190,10 +188,8 @@ function parseF1(html: string, rootPath: string): Entry[] {
           }
         }
 
-        // create path by joining rootPath with href
-        const path = /^https?:\/\//.test(href)
-          ? href
-          : `${rootPath}/${href}`;
+        // use just the href as path
+        const path = href;
 
         if (type === "directory") {
           entries.push({
@@ -218,7 +214,7 @@ function parseF1(html: string, rootPath: string): Entry[] {
   return entries;
 }
 
-function parseF2(html: string, rootPath: string): Entry[] {
+function parseF2(html: string): Entry[] {
   const entries: Entry[] = [];
 
   // find the table and extract rows
@@ -288,10 +284,8 @@ function parseF2(html: string, rootPath: string): Entry[] {
     // determine type
     const type = imgAlt === "[DIR]" || href.endsWith("/") ? "directory" : "file";
 
-    // create path by joining rootPath with href
-    const path = /^https?:\/\//.test(href)
-      ? href
-      : `${rootPath}/${href}`;
+    // use just the href as path
+    const path = href;
 
     if (type === "directory") {
       entries.push({

--- a/src/traverse.ts
+++ b/src/traverse.ts
@@ -58,6 +58,7 @@ export async function traverse(rootUrl: string, options?: TraverseOptions): Prom
     await Promise.all(
       root.children.map(async (entry) => {
         if (entry.type === "directory") {
+          // Combine rootUrl with entry.path since entry.path is now relative
           const childUrl = new URL(entry.path, rootUrl).href;
           const child = await traverse(childUrl, options);
           if (child) {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -12,23 +12,23 @@ it("should parse apache index files (F=0)", () => {
   const paths = entry?.children.map((entry) => entry.path);
 
   expect(paths).toStrictEqual([
-    "/Public/emoji/1.0/",
-    "/Public/emoji/2.0/",
-    "/Public/emoji/3.0/",
-    "/Public/emoji/4.0/",
-    "/Public/emoji/5.0/",
-    "/Public/emoji/11.0/",
-    "/Public/emoji/12.0/",
-    "/Public/emoji/12.1/",
-    "/Public/emoji/13.0/",
-    "/Public/emoji/13.1/",
-    "/Public/emoji/14.0/",
-    "/Public/emoji/15.0/",
-    "/Public/emoji/15.1/",
-    "/Public/emoji/16.0/",
-    "/Public/emoji/17.0/",
-    "/Public/emoji/ReadMe.txt",
-    "/Public/emoji/latest/",
+    "1.0/",
+    "2.0/",
+    "3.0/",
+    "4.0/",
+    "5.0/",
+    "11.0/",
+    "12.0/",
+    "12.1/",
+    "13.0/",
+    "13.1/",
+    "14.0/",
+    "15.0/",
+    "15.1/",
+    "16.0/",
+    "17.0/",
+    "ReadMe.txt",
+    "latest/",
   ]);
 
   const files = entry?.children.filter((entry) => entry.type === "file");
@@ -38,7 +38,7 @@ it("should parse apache index files (F=0)", () => {
     {
       type: "file",
       name: "ReadMe.txt",
-      path: "/Public/emoji/ReadMe.txt",
+      path: "ReadMe.txt",
       lastModified: undefined,
     },
   ]);
@@ -54,23 +54,23 @@ it("should parse apache index files (F=1)", () => {
   const paths = entry?.children.map((entry) => entry.path);
 
   expect(paths).toStrictEqual([
-    "/Public/emoji/1.0/",
-    "/Public/emoji/2.0/",
-    "/Public/emoji/3.0/",
-    "/Public/emoji/4.0/",
-    "/Public/emoji/5.0/",
-    "/Public/emoji/11.0/",
-    "/Public/emoji/12.0/",
-    "/Public/emoji/12.1/",
-    "/Public/emoji/13.0/",
-    "/Public/emoji/13.1/",
-    "/Public/emoji/14.0/",
-    "/Public/emoji/15.0/",
-    "/Public/emoji/15.1/",
-    "/Public/emoji/16.0/",
-    "/Public/emoji/17.0/",
-    "/Public/emoji/ReadMe.txt",
-    "/Public/emoji/latest/",
+    "1.0/",
+    "2.0/",
+    "3.0/",
+    "4.0/",
+    "5.0/",
+    "11.0/",
+    "12.0/",
+    "12.1/",
+    "13.0/",
+    "13.1/",
+    "14.0/",
+    "15.0/",
+    "15.1/",
+    "16.0/",
+    "17.0/",
+    "ReadMe.txt",
+    "latest/",
   ]);
 
   const files = entry?.children.filter((entry) => entry.type === "file");
@@ -80,7 +80,7 @@ it("should parse apache index files (F=1)", () => {
     {
       type: "file",
       name: "ReadMe.txt",
-      path: "/Public/emoji/ReadMe.txt",
+      path: "ReadMe.txt",
       lastModified: expect.any(Number),
     },
   ]);
@@ -96,23 +96,23 @@ it("should parse apache index files (F=2)", () => {
   const paths = entry?.children.map((entry) => entry.path);
 
   expect(paths).toStrictEqual([
-    "/Public/emoji/1.0/",
-    "/Public/emoji/2.0/",
-    "/Public/emoji/3.0/",
-    "/Public/emoji/4.0/",
-    "/Public/emoji/5.0/",
-    "/Public/emoji/11.0/",
-    "/Public/emoji/12.0/",
-    "/Public/emoji/12.1/",
-    "/Public/emoji/13.0/",
-    "/Public/emoji/13.1/",
-    "/Public/emoji/14.0/",
-    "/Public/emoji/15.0/",
-    "/Public/emoji/15.1/",
-    "/Public/emoji/16.0/",
-    "/Public/emoji/17.0/",
-    "/Public/emoji/ReadMe.txt",
-    "/Public/emoji/latest/",
+    "1.0/",
+    "2.0/",
+    "3.0/",
+    "4.0/",
+    "5.0/",
+    "11.0/",
+    "12.0/",
+    "12.1/",
+    "13.0/",
+    "13.1/",
+    "14.0/",
+    "15.0/",
+    "15.1/",
+    "16.0/",
+    "17.0/",
+    "ReadMe.txt",
+    "latest/",
   ]);
 
   const files = entry?.children.filter((entry) => entry.type === "file");
@@ -122,7 +122,7 @@ it("should parse apache index files (F=2)", () => {
     {
       type: "file",
       name: "ReadMe.txt",
-      path: "/Public/emoji/ReadMe.txt",
+      path: "ReadMe.txt",
       lastModified: expect.any(Number),
     },
   ]);
@@ -139,23 +139,23 @@ describe("auto-inferred format", () => {
     const paths = entry?.children.map((entry) => entry.path);
 
     expect(paths).toStrictEqual([
-      "/Public/emoji/1.0/",
-      "/Public/emoji/2.0/",
-      "/Public/emoji/3.0/",
-      "/Public/emoji/4.0/",
-      "/Public/emoji/5.0/",
-      "/Public/emoji/11.0/",
-      "/Public/emoji/12.0/",
-      "/Public/emoji/12.1/",
-      "/Public/emoji/13.0/",
-      "/Public/emoji/13.1/",
-      "/Public/emoji/14.0/",
-      "/Public/emoji/15.0/",
-      "/Public/emoji/15.1/",
-      "/Public/emoji/16.0/",
-      "/Public/emoji/17.0/",
-      "/Public/emoji/ReadMe.txt",
-      "/Public/emoji/latest/",
+      "1.0/",
+      "2.0/",
+      "3.0/",
+      "4.0/",
+      "5.0/",
+      "11.0/",
+      "12.0/",
+      "12.1/",
+      "13.0/",
+      "13.1/",
+      "14.0/",
+      "15.0/",
+      "15.1/",
+      "16.0/",
+      "17.0/",
+      "ReadMe.txt",
+      "latest/",
     ]);
 
     const lastModified = entry?.children.map((entry) => entry.lastModified);
@@ -169,7 +169,7 @@ describe("auto-inferred format", () => {
       {
         type: "file",
         name: "ReadMe.txt",
-        path: "/Public/emoji/ReadMe.txt",
+        path: "ReadMe.txt",
         lastModified: undefined,
       },
     ]);
@@ -185,23 +185,23 @@ describe("auto-inferred format", () => {
     const paths = entry?.children.map((entry) => entry.path);
 
     expect(paths).toStrictEqual([
-      "/Public/emoji/1.0/",
-      "/Public/emoji/2.0/",
-      "/Public/emoji/3.0/",
-      "/Public/emoji/4.0/",
-      "/Public/emoji/5.0/",
-      "/Public/emoji/11.0/",
-      "/Public/emoji/12.0/",
-      "/Public/emoji/12.1/",
-      "/Public/emoji/13.0/",
-      "/Public/emoji/13.1/",
-      "/Public/emoji/14.0/",
-      "/Public/emoji/15.0/",
-      "/Public/emoji/15.1/",
-      "/Public/emoji/16.0/",
-      "/Public/emoji/17.0/",
-      "/Public/emoji/ReadMe.txt",
-      "/Public/emoji/latest/",
+      "1.0/",
+      "2.0/",
+      "3.0/",
+      "4.0/",
+      "5.0/",
+      "11.0/",
+      "12.0/",
+      "12.1/",
+      "13.0/",
+      "13.1/",
+      "14.0/",
+      "15.0/",
+      "15.1/",
+      "16.0/",
+      "17.0/",
+      "ReadMe.txt",
+      "latest/",
     ]);
 
     const lastModified = entry?.children.map((entry) => entry.lastModified);
@@ -215,7 +215,7 @@ describe("auto-inferred format", () => {
       {
         type: "file",
         name: "ReadMe.txt",
-        path: "/Public/emoji/ReadMe.txt",
+        path: "ReadMe.txt",
         lastModified: expect.any(Number),
       },
     ]);


### PR DESCRIPTION
This PR removes the root path from being part of the path, the full path can still be created by joing it from parent down to child.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Paths in parsed directory listings now use relative URLs instead of absolute URLs.

- **Tests**
  - Updated test cases to expect and validate relative paths in parsed results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->