### PR TITLE
feat: use testcontainers for integration tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: setup pnpm
         uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
 
-      - name: seyup node
+      - name: setup node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: lts/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 dist
 node_modules
-httpd
+.vitest-testdirs

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "eslint": "^9.29.0",
     "eslint-plugin-format": "^1.0.1",
     "publint": "^0.3.12",
+    "testcontainers": "^11.0.3",
     "tsdown": "^0.12.8",
     "typescript": "^5.8.3",
     "vitest": "^3.2.4"

--- a/package.json
+++ b/package.json
@@ -60,7 +60,8 @@
     "testcontainers": "^11.0.3",
     "tsdown": "^0.12.8",
     "typescript": "^5.8.3",
-    "vitest": "^3.2.4"
+    "vitest": "^3.2.4",
+    "vitest-testdirs": "^4.0.1"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,9 @@ importers:
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/debug@4.1.12)(@types/node@22.15.32)(jiti@2.4.2)(yaml@2.8.0)
+      vitest-testdirs:
+        specifier: ^4.0.1
+        version: 4.0.1(vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.15.32)(jiti@2.4.2)(yaml@2.8.0))
 
 packages:
 
@@ -2224,6 +2227,10 @@ packages:
   testcontainers@11.0.3:
     resolution: {integrity: sha512-Xu6ZAaE1FaLyHzFSYdCsd+xMPxUegUjkum0r6zgO8SinnFDHRX/PllIHMt1D+DVUmJqBvPQI6vge/J5jgE5vng==}
 
+  testdirs@3.0.0:
+    resolution: {integrity: sha512-2G7stHEavnUbvsS9LyGieuVyUVNVXAgeMfqiUtebmA63yJSgC6JBv3eTk3rmmDfrjB8wv1z+45Bn/awEI6e/yw==}
+    engines: {node: '>=20'}
+
   text-decoder@1.2.3:
     resolution: {integrity: sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==}
 
@@ -2400,6 +2407,12 @@ packages:
         optional: true
       yaml:
         optional: true
+
+  vitest-testdirs@4.0.1:
+    resolution: {integrity: sha512-yCXgvSQG8XXn++PnnKX5Fzmfm8y7u4fjhBqwFQz8aLFjdIualWrCGd0sC4UYKUE/mX+AWL3DqECwbmep+8TEQw==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      vitest: '>=2.0.5 <4.0.0'
 
   vitest@3.2.4:
     resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
@@ -4929,6 +4942,8 @@ snapshots:
       - bare-buffer
       - supports-color
 
+  testdirs@3.0.0: {}
+
   text-decoder@1.2.3:
     dependencies:
       b4a: 1.6.7
@@ -5085,6 +5100,11 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.4.2
       yaml: 2.8.0
+
+  vitest-testdirs@4.0.1(vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.15.32)(jiti@2.4.2)(yaml@2.8.0)):
+    dependencies:
+      testdirs: 3.0.0
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.15.32)(jiti@2.4.2)(yaml@2.8.0)
 
   vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.15.32)(jiti@2.4.2)(yaml@2.8.0):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,9 @@ importers:
       publint:
         specifier: ^0.3.12
         version: 0.3.12
+      testcontainers:
+        specifier: ^11.0.3
+        version: 11.0.3
       tsdown:
         specifier: ^0.12.8
         version: 0.12.8(publint@0.3.12)(typescript@5.8.3)
@@ -62,6 +65,9 @@ packages:
   '@babel/types@7.27.6':
     resolution: {integrity: sha512-ETyHEk2VHHvl9b9jZP5IHPavHYk57EhanlRRuae9XCpb/j5bDCbPPMOBfCWhnl/7EDJz0jEMCi/RhccCE8r1+Q==}
     engines: {node: '>=6.9.0'}
+
+  '@balena/dockerignore@1.0.2':
+    resolution: {integrity: sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q==}
 
   '@clack/core@0.5.0':
     resolution: {integrity: sha512-p3y0FIOwaYRUPRcMO7+dlmLh8PSRcrjuTndsiA0WAFbWES0mLZlrjVoBRZ9DzkPFJZG6KGkJmoEAY0ZcVWTkow==}
@@ -310,6 +316,15 @@ packages:
     resolution: {integrity: sha512-4SaFZCNfJqvk/kenHpI8xvN42DMaoycy4PzKc5otHxRswww1kAt82OlBuwRVLofCACCTZEcla2Ydxv8scMXaTg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@grpc/grpc-js@1.13.4':
+    resolution: {integrity: sha512-GsFaMXCkMqkKIvwCQjCrwH+GHbPKBjhwo/8ZuUkWHqbI73Kky9I+pQltrlT0+MWpedCoosda53lgjYfyEPgxBg==}
+    engines: {node: '>=12.10.0'}
+
+  '@grpc/proto-loader@0.7.15':
+    resolution: {integrity: sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==}
+    engines: {node: '>=6'}
+    hasBin: true
+
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
     engines: {node: '>=18.18.0'}
@@ -330,6 +345,10 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
+  '@isaacs/cliui@8.0.2':
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
+
   '@jridgewell/gen-mapping@0.3.8':
     resolution: {integrity: sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==}
     engines: {node: '>=6.0.0'}
@@ -347,6 +366,9 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
+
+  '@js-sdsl/ordered-map@4.4.2':
+    resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
 
   '@luxass/eslint-config@5.0.0':
     resolution: {integrity: sha512-nlzXBH7YRxJt+hlRomYHhC0mjhMNjz8gxJV7FOGEnUMZjAlAAYzXNtI3yLvqXAP8q6lMznPMRhjNXoY8/O2JZg==}
@@ -404,6 +426,10 @@ packages:
   '@oxc-project/types@0.72.3':
     resolution: {integrity: sha512-CfAC4wrmMkUoISpQkFAIfMVvlPfQV3xg7ZlcqPXPOIMQhdKIId44G8W0mCPgtpWdFFAyJ+SFtiM+9vbyCkoVng==}
 
+  '@pkgjs/parseargs@0.11.0':
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
+
   '@pkgr/core@0.1.2':
     resolution: {integrity: sha512-fdDH1LSGfZdTH2sxdpVMw31BanV28K/Gry0cVFxaNP77neJSkd82mM8ErPNYs9e+0O7SdHBLTDzDgwUuy18RnQ==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
@@ -411,6 +437,36 @@ packages:
   '@pkgr/core@0.2.7':
     resolution: {integrity: sha512-YLT9Zo3oNPJoBjBc4q8G2mjU4tqIbf5CEOORbUUr48dCD9q3umJ3IPlVqOqDakPfd2HuwccBaqlGhN4Gmr5OWg==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
+
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.4':
+    resolution: {integrity: sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==}
+
+  '@protobufjs/eventemitter@1.1.0':
+    resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
+
+  '@protobufjs/fetch@1.1.0':
+    resolution: {integrity: sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/inquire@1.1.0':
+    resolution: {integrity: sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.0':
+    resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
 
   '@publint/pack@0.1.2':
     resolution: {integrity: sha512-S+9ANAvUmjutrshV4jZjaiG8XQyuJIZ8a4utWmN/vW1sgQ9IfBnPndwkmQYw53QmouOIytT874u65HEmu6H5jw==}
@@ -601,6 +657,12 @@ packages:
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
+  '@types/docker-modem@3.0.6':
+    resolution: {integrity: sha512-yKpAGEuKRSS8wwx0joknWxsmLha78wNMe9R2S3UNsVOkZded8UqOrV8KoeDXoXsjndxwyF3eIhyClGbO1SEhEg==}
+
+  '@types/dockerode@3.3.41':
+    resolution: {integrity: sha512-5kOi6bcnEjqfJ68ZNV/bBvSMLNIucc0XbRmBO4hg5OoFCoP99eSRcbMysjkzV7ZxQEmmc/zMnv4A7odwuKFzDA==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -613,8 +675,20 @@ packages:
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
+  '@types/node@18.19.112':
+    resolution: {integrity: sha512-i+Vukt9POdS/MBI7YrrkkI5fMfwFtOjphSmt4WXYLfwqsfr6z/HdCx7LqT9M7JktGob8WNgj8nFB4TbGNE4Cog==}
+
   '@types/node@22.15.32':
     resolution: {integrity: sha512-3jigKqgSjsH6gYZv2nEsqdXfZqIFGAV36XYYjf9KGZ3PSG+IhLecqPnI310RvjutyMwifE2hhhNEklOUrvx/wA==}
+
+  '@types/ssh2-streams@0.1.12':
+    resolution: {integrity: sha512-Sy8tpEmCce4Tq0oSOYdfqaBpA3hDM8SoxoFh5vzFsu2oL+znzGz8oVWW7xb4K920yYMUY+PIG31qZnFMfPWNCg==}
+
+  '@types/ssh2@0.5.52':
+    resolution: {integrity: sha512-lbLLlXxdCZOSJMCInKH2+9V/77ET2J6NPQHpFI0kda61Dd1KglJs+fPQBchizmzYSOJBgdTajhPqBO1xxLywvg==}
+
+  '@types/ssh2@1.15.5':
+    resolution: {integrity: sha512-N1ASjp/nXH3ovBHddRJpli4ozpk6UdDYIX4RJWFa9L1YKnzdhTlVmiGHm4DZnj/jLbqZpes4aeR30EFGQtvhQQ==}
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
@@ -734,6 +808,10 @@ packages:
   '@vue/shared@3.5.17':
     resolution: {integrity: sha512-CabR+UN630VnsJO/jHWYBC1YVXyMq94KKp6iF5MQgZJs5I8cmjw6oVMO1oDbtBkENSHSSn/UadWlW/OAgdmKrg==}
 
+  abort-controller@3.0.0:
+    resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
+    engines: {node: '>=6.5'}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -747,13 +825,33 @@ packages:
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
 
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-regex@6.1.0:
+    resolution: {integrity: sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==}
+    engines: {node: '>=12'}
+
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@6.2.1:
+    resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
+    engines: {node: '>=12'}
+
   ansis@4.1.0:
     resolution: {integrity: sha512-BGcItUBWSMRgOCe+SVZJ+S7yTRG0eGt9cXAHev72yuGcY23hnLA7Bky5L/xLyPINoSN95geovfBkqoTlNZYa7w==}
     engines: {node: '>=14'}
+
+  archiver-utils@5.0.2:
+    resolution: {integrity: sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==}
+    engines: {node: '>= 14'}
+
+  archiver@7.0.1:
+    resolution: {integrity: sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==}
+    engines: {node: '>= 14'}
 
   are-docs-informative@0.0.2:
     resolution: {integrity: sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==}
@@ -761,6 +859,9 @@ packages:
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  asn1@0.2.6:
+    resolution: {integrity: sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==}
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
@@ -770,11 +871,59 @@ packages:
     resolution: {integrity: sha512-ROM2LlXbZBZVk97crfw8PGDOBzzsJvN2uJCmwswvPUNyfH14eg90mSN3xNqsri1JS1G9cz0VzeDUhxJkTrr4Ew==}
     engines: {node: '>=20.18.0'}
 
+  async-lock@1.4.1:
+    resolution: {integrity: sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ==}
+
+  async@3.2.6:
+    resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
+
+  b4a@1.6.7:
+    resolution: {integrity: sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg==}
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  bare-events@2.5.4:
+    resolution: {integrity: sha512-+gFfDkR8pj4/TrWCGUGWmJIkBwuxPS5F+a5yWjOHQt2hHvNZd5YLzadjmDUtFmMM4y429bnKLa8bYBMHcYdnQA==}
+
+  bare-fs@4.1.5:
+    resolution: {integrity: sha512-1zccWBMypln0jEE05LzZt+V/8y8AQsQQqxtklqaIyg5nu6OAYFhZxPXinJTSG+kU5qyNmeLgcn9AW7eHiCHVLA==}
+    engines: {bare: '>=1.16.0'}
+    peerDependencies:
+      bare-buffer: '*'
+    peerDependenciesMeta:
+      bare-buffer:
+        optional: true
+
+  bare-os@3.6.1:
+    resolution: {integrity: sha512-uaIjxokhFidJP+bmmvKSgiMzj2sV5GPHaZVAIktcxcpCyBFFWO+YlikVAdhmUo2vYFvFhOXIAlldqV29L8126g==}
+    engines: {bare: '>=1.14.0'}
+
+  bare-path@3.0.0:
+    resolution: {integrity: sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==}
+
+  bare-stream@2.6.5:
+    resolution: {integrity: sha512-jSmxKJNJmHySi6hC42zlZnq00rga4jjxcgNZjY9N5WlOe/iOoGRtdwGsHzQv2RlH2KOYMwGUXhf2zXd32BA9RA==}
+    peerDependencies:
+      bare-buffer: '*'
+      bare-events: '*'
+    peerDependenciesMeta:
+      bare-buffer:
+        optional: true
+      bare-events:
+        optional: true
+
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
+  bcrypt-pbkdf@1.0.2:
+    resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
+
   birpc@2.4.0:
     resolution: {integrity: sha512-5IdNxTyhXHv2UlgnPHQ0h+5ypVmkrYHzL8QT+DwFZ//2N/oNV8Ch+BCRmTJ3x6/z9Axo/cXYBc9eprsUVK/Jsg==}
+
+  bl@4.1.0:
+    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
@@ -794,9 +943,27 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
+  buffer-crc32@1.0.0:
+    resolution: {integrity: sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==}
+    engines: {node: '>=8.0.0'}
+
+  buffer@5.7.1:
+    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
+
+  buffer@6.0.3:
+    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
+
+  buildcheck@0.0.6:
+    resolution: {integrity: sha512-8f9ZJCUXyT1M35Jx7MkBgmBMo3oHTTBIPLiY9xyL0pl3T5RwcPEY8cUHr5LBNfu/fk6c2T4DJZuVM/8ZZT2D2A==}
+    engines: {node: '>=10.0.0'}
+
   builtin-modules@5.0.0:
     resolution: {integrity: sha512-bkXY9WsVpY7CvMhKSR6pZilZu9Ln5WDrKVBUXf2S443etkmEO4V58heTecXcUIsNsi4Rx8JUO4NfX1IcQl4deg==}
     engines: {node: '>=18.20'}
+
+  byline@5.0.0:
+    resolution: {integrity: sha512-s6webAy+R4SR8XVuJWt2V2rGvhnrhxN+9S15GNuTK3wKPOXFF6RNc+8ug2XhH+2s4f+uudG4kUVYmYOQWL2g0Q==}
+    engines: {node: '>=0.10.0'}
 
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
@@ -831,6 +998,9 @@ packages:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
 
+  chownr@1.1.4:
+    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
+
   ci-info@4.2.0:
     resolution: {integrity: sha512-cYY9mypksY8NRqgDB1XD1RiJL338v/551niynFTGkZOO2LHuB2OmOYxDIe/ttN9AHwrqdum1360G3ald0W9kCg==}
     engines: {node: '>=8'}
@@ -838,6 +1008,10 @@ packages:
   clean-regexp@1.0.0:
     resolution: {integrity: sha512-GfisEZEJvzKrmGWkvfhgzcz/BllN1USeqD2V6tg14OAOgaCD2Z/PUEuxnAZ/nPvmaHRG7a8y77p1T/IRQ4D1Hw==}
     engines: {node: '>=4'}
+
+  cliui@8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -850,6 +1024,10 @@ packages:
     resolution: {integrity: sha512-buhp5kePrmda3vhc5B9t7pUQXAb2Tnd0qgpkIhPhkHXxJpiPJ11H0ZEU0oBpJ2QztSbzG/ZxMj/CHsYJqRHmyg==}
     engines: {node: '>= 12.0.0'}
 
+  compress-commons@6.0.2:
+    resolution: {integrity: sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==}
+    engines: {node: '>= 14'}
+
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
@@ -861,6 +1039,22 @@ packages:
 
   core-js-compat@3.43.0:
     resolution: {integrity: sha512-2GML2ZsCc5LR7hZYz4AXmjQw8zuy2T//2QntwdnpuYI7jteT6GVYJL7F6C2C57R7gSYrcqVW3lAALefdbhBLDA==}
+
+  core-util-is@1.0.3:
+    resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
+  cpu-features@0.0.10:
+    resolution: {integrity: sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==}
+    engines: {node: '>=10.0.0'}
+
+  crc-32@1.2.2:
+    resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
+    engines: {node: '>=0.8'}
+    hasBin: true
+
+  crc32-stream@6.0.0:
+    resolution: {integrity: sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g==}
+    engines: {node: '>= 14'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -911,6 +1105,18 @@ packages:
     resolution: {integrity: sha512-sSuxWU5j5SR9QQji/o2qMvqRNYRDOcBTgsJ/DeCf4iSN4gW+gNMXM7wFIP+fdXZxoNiAnHUTGjCr+TSWXdRDKg==}
     engines: {node: '>=0.3.1'}
 
+  docker-compose@1.2.0:
+    resolution: {integrity: sha512-wIU1eHk3Op7dFgELRdmOYlPYS4gP8HhH1ZmZa13QZF59y0fblzFDFmKPhyc05phCy2hze9OEvNZAsoljrs+72w==}
+    engines: {node: '>= 6.0.0'}
+
+  docker-modem@5.0.6:
+    resolution: {integrity: sha512-ens7BiayssQz/uAxGzH8zGXCtiV24rRWXdjNha5V4zSOcxmAZsfGVm/PPFbwQdqEkDnhG+SyR9E3zSHUbOKXBQ==}
+    engines: {node: '>= 8.0'}
+
+  dockerode@4.0.7:
+    resolution: {integrity: sha512-R+rgrSRTRdU5mH14PZTCPZtW/zw3HDWNTS/1ZAQpL/5Upe/ye5K9WQkIysu4wBoiMwKynsz0a8qWuGsHgEvSAA==}
+    engines: {node: '>= 8.0'}
+
   dom-serializer@2.0.0:
     resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
 
@@ -933,12 +1139,24 @@ packages:
       oxc-resolver:
         optional: true
 
+  eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
   electron-to-chromium@1.5.171:
     resolution: {integrity: sha512-scWpzXEJEMrGJa4Y6m/tVotb0WuvNmasv3wWVzUAeCgKU0ToFOhUW6Z+xWnRQANMYGxN4ngJXIThgBJOqzVPCQ==}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  emoji-regex@9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
   empathic@1.1.0:
     resolution: {integrity: sha512-rsPft6CK3eHtrlp9Y5ALBb+hfK+DWnA4WFebbazxjWyx8vSm3rZeoM3z9irsjcqO3PYRzlfv27XIB4tz2DV7RA==}
     engines: {node: '>=14'}
+
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
   enhanced-resolve@5.18.1:
     resolution: {integrity: sha512-ZSW3ma5GkcQBIpwZTSRAI8N71Uuwgs93IezB7mf7R60tC8ZbJideoDNKjHn2O9KIlx6rkGTTEk1xUCK2E1Y2Yg==}
@@ -1169,6 +1387,14 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  event-target-shim@5.0.1:
+    resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
+    engines: {node: '>=6'}
+
+  events@3.3.0:
+    resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
+    engines: {node: '>=0.8.x'}
+
   expect-type@1.2.1:
     resolution: {integrity: sha512-/kP8CAwxzLVEeFrMm4kMmy4CCDlpipyA7MYLVrdJIkV0fYF0UaigQHRsxHiuY/GEea+bh4KSv3TIlgr+2UL6bw==}
     engines: {node: '>=12.0.0'}
@@ -1181,6 +1407,9 @@ packages:
 
   fast-diff@1.3.0:
     resolution: {integrity: sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==}
+
+  fast-fifo@1.3.2:
+    resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
 
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
@@ -1229,14 +1458,29 @@ packages:
   flatted@3.3.3:
     resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
 
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
+
   format@0.2.2:
     resolution: {integrity: sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==}
     engines: {node: '>=0.4.x'}
+
+  fs-constants@1.0.0:
+    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+
+  get-port@7.1.0:
+    resolution: {integrity: sha512-QB9NKEeDg3xxVwCCwJQ9+xycaz6pBB6iQ76wiWMl1927n0Kir6alPiP+yuiICLLU4jpMe08dXfpebuQppFA2zw==}
+    engines: {node: '>=16'}
 
   get-tsconfig@4.10.1:
     resolution: {integrity: sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==}
@@ -1251,6 +1495,10 @@ packages:
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
+
+  glob@10.4.5:
+    resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    hasBin: true
 
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
@@ -1281,6 +1529,9 @@ packages:
   hookable@5.5.3:
     resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
 
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -1301,6 +1552,9 @@ packages:
     resolution: {integrity: sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==}
     engines: {node: '>=12'}
 
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
   is-builtin-module@5.0.0:
     resolution: {integrity: sha512-f4RqJKBUe5rQkJ2eJEJBXSticB3hGbN9j0yxxMQFqIW89Jp9WYFtzfTcRlstDKVUTRzSOTLKRfO9vIztenwtxA==}
     engines: {node: '>=18.20'}
@@ -1308,6 +1562,10 @@ packages:
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
 
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
@@ -1317,8 +1575,18 @@ packages:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
 
+  is-stream@2.0.1:
+    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
+    engines: {node: '>=8'}
+
+  isarray@1.0.0:
+    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
+
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  jackspeak@3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
   jiti@2.4.2:
     resolution: {integrity: sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==}
@@ -1361,6 +1629,10 @@ packages:
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
+  lazystream@1.0.1:
+    resolution: {integrity: sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==}
+    engines: {node: '>= 0.6.3'}
+
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
@@ -1373,17 +1645,26 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
+  lodash.camelcase@4.3.0:
+    resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
+
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
   lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
 
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
+
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
 
   loupe@3.1.4:
     resolution: {integrity: sha512-wJzkKwJrheKtknCOKNEtDK4iqg/MxmZheEMtSTYvnzRdEYaZzmgH976nenp8WdJRdx5Vc1X/9MO0Oszl6ezeXg==}
+
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
@@ -1529,9 +1810,25 @@ packages:
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
 
+  minimatch@5.1.6:
+    resolution: {integrity: sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==}
+    engines: {node: '>=10'}
+
   minimatch@9.0.5:
     resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
     engines: {node: '>=16 || 14 >=14.17'}
+
+  minipass@7.1.2:
+    resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  mkdirp-classic@0.5.3:
+    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
+
+  mkdirp@1.0.4:
+    resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
+    engines: {node: '>=10'}
+    hasBin: true
 
   mlly@1.7.4:
     resolution: {integrity: sha512-qmdSIPC4bDJXgZTCR7XosJiNKySV7O215tsPtDN9iEO/7q/76b/ijtgRu/+epFXSJhijtTCCGp3DWS549P3xKw==}
@@ -1542,6 +1839,9 @@ packages:
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nan@2.22.2:
+    resolution: {integrity: sha512-DANghxFkS1plDdRsX0X9pm0Z6SJNN6gBdtXfanwoZ8hooC5gosGFSBGRYHUVPz1asKA/kMRqDRdHrluZ61SpBQ==}
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
@@ -1561,8 +1861,15 @@ packages:
   node-releases@2.0.19:
     resolution: {integrity: sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==}
 
+  normalize-path@3.0.0:
+    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
+    engines: {node: '>=0.10.0'}
+
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -1575,6 +1882,9 @@ packages:
   p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
+
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
   package-manager-detector@1.3.0:
     resolution: {integrity: sha512-ZsEbbZORsyHuO00lY1kV3/t72yp6Ysay6Pd17ZAlNGuGwmWDLCJxFpRs0IzfXfj1o4icJOkUEioexFHzyPurSQ==}
@@ -1600,6 +1910,10 @@ packages:
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+
+  path-scurry@1.11.1:
+    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
+    engines: {node: '>=16 || 14 >=14.18'}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -1653,10 +1967,31 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  process-nextick-args@2.0.1:
+    resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
+
+  process@0.11.10:
+    resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
+    engines: {node: '>= 0.6.0'}
+
+  proper-lockfile@4.1.2:
+    resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
+
+  properties-reader@2.3.0:
+    resolution: {integrity: sha512-z597WicA7nDZxK12kZqHr2TcvwNU1GCfA5UwfDY/HDp3hXPoPlb5rlEx9bwGTiJnc0OqbBTkU975jDToth8Gxw==}
+    engines: {node: '>=14'}
+
+  protobufjs@7.5.3:
+    resolution: {integrity: sha512-sildjKwVqOI2kmFDiXQ6aEB0fjYTafpEvIBs8tOR8qI4spuL9OPROLVu2qZqi/xgCfsHIwVqlaF8JBjWFHnKbw==}
+    engines: {node: '>=12.0.0'}
+
   publint@0.3.12:
     resolution: {integrity: sha512-1w3MMtL9iotBjm1mmXtG3Nk06wnq9UhGNRpQ2j6n1Zq7YAD6gnxMMZMIxlRPAydVjVbjSm+n0lhwqsD1m4LD5w==}
     engines: {node: '>=18'}
     hasBin: true
+
+  pump@3.0.3:
+    resolution: {integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -1667,6 +2002,20 @@ packages:
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  readable-stream@2.3.8:
+    resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
+
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
+
+  readable-stream@4.7.0:
+    resolution: {integrity: sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  readdir-glob@1.1.3:
+    resolution: {integrity: sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==}
 
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
@@ -1688,12 +2037,20 @@ packages:
     resolution: {integrity: sha512-cnE+y8bz4NhMjISKbgeVJtqNbtf5QpjZP+Bslo+UqkIt9QPnX9q095eiRRASJG1/tz6dlNr6Z5NsBiWYokp6EQ==}
     hasBin: true
 
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  retry@0.12.0:
+    resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
+    engines: {node: '>= 4'}
 
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
@@ -1731,6 +2088,15 @@ packages:
     resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
     engines: {node: '>=6'}
 
+  safe-buffer@5.1.2:
+    resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
   scslre@0.3.0:
     resolution: {integrity: sha512-3A6sD0WYP7+QrjbfNA2FN3FsOaGGFoekCVgTyypy53gPxhbkCIjtO6YWgdrfM+n/8sI8JeXZOIxsHjMTNxQ4nQ==}
     engines: {node: ^14.0.0 || >=16.0.0}
@@ -1751,6 +2117,13 @@ packages:
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
+  signal-exit@3.0.7:
+    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
+
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
@@ -1767,11 +2140,46 @@ packages:
   spdx-license-ids@3.0.21:
     resolution: {integrity: sha512-Bvg/8F5XephndSK3JffaRqdT+gyhfqIPwDHpX80tJrF8QQRYMo8sNMeaZ2Dp5+jhwKnUmIOyFFQfHRkjJm5nXg==}
 
+  split-ca@1.0.1:
+    resolution: {integrity: sha512-Q5thBSxp5t8WPTTJQS59LrGqOZqOsrhDGDVm8azCqIBjSBd7nd9o2PM+mDulQQkh8h//4U6hFZnc/mul8t5pWQ==}
+
+  ssh-remote-port-forward@1.0.4:
+    resolution: {integrity: sha512-x0LV1eVDwjf1gmG7TTnfqIzf+3VPRz7vrNIjX6oYLbeCrf/PeVY6hkT68Mg+q02qXxQhrLjB0jfgvhevoCRmLQ==}
+
+  ssh2@1.16.0:
+    resolution: {integrity: sha512-r1X4KsBGedJqo7h8F5c4Ybpcr5RjyP+aWIG007uBPRjmdQWfEiVLzSK71Zji1B9sKxwaCvD8y8cwSkYrlLiRRg==}
+    engines: {node: '>=10.16.0'}
+
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
   std-env@3.9.0:
     resolution: {integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==}
+
+  streamx@2.22.1:
+    resolution: {integrity: sha512-znKXEBxfatz2GBNK02kRnCXjV+AA4kjZIUxeWSr3UGirZMJfTE9uiwKHobnbgxWyL/JWro8tTq+vOqAK1/qbSA==}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
+
+  string_decoder@1.1.1:
+    resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
+
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
+  strip-ansi@7.1.0:
+    resolution: {integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==}
+    engines: {node: '>=12'}
 
   strip-indent@4.0.0:
     resolution: {integrity: sha512-mnVSV2l+Zv6BLpSD/8V87CW/y9EmmbYzGCIavsnsI6/nwn26DwffM/yztm30Z/I2DY9wdS3vXVCMnHDgZaVNoA==}
@@ -1800,6 +2208,25 @@ packages:
     resolution: {integrity: sha512-Re10+NauLTMCudc7T5WLFLAwDhQ0JWdrMK+9B2M8zR5hRExKmsRDCBA7/aV/pNJFltmBFO5BAMlQFi/vq3nKOg==}
     engines: {node: '>=6'}
 
+  tar-fs@2.1.3:
+    resolution: {integrity: sha512-090nwYJDmlhwFwEW3QQl+vaNnxsO2yVsd45eTKRBzSzu+hlb1w2K9inVq5b0ngXuLVqQ4ApvsUHHnu/zQNkWAg==}
+
+  tar-fs@3.0.10:
+    resolution: {integrity: sha512-C1SwlQGNLe/jPNqapK8epDsXME7CAJR5RL3GcE6KWx1d9OUByzoHVcbu1VPI8tevg9H8Alae0AApHHFGzrD5zA==}
+
+  tar-stream@2.2.0:
+    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
+    engines: {node: '>=6'}
+
+  tar-stream@3.1.7:
+    resolution: {integrity: sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==}
+
+  testcontainers@11.0.3:
+    resolution: {integrity: sha512-Xu6ZAaE1FaLyHzFSYdCsd+xMPxUegUjkum0r6zgO8SinnFDHRX/PllIHMt1D+DVUmJqBvPQI6vge/J5jgE5vng==}
+
+  text-decoder@1.2.3:
+    resolution: {integrity: sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==}
+
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -1824,6 +2251,10 @@ packages:
   tinyspy@4.0.3:
     resolution: {integrity: sha512-t2T/WLB2WRgZ9EpE4jgPJ9w+i66UZfDc8wHh0xrwiRNN+UwH98GIJkTeZqX9rg0i0ptwzqW+uYeIF0T4F8LR7A==}
     engines: {node: '>=14.0.0'}
+
+  tmp@0.2.3:
+    resolution: {integrity: sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==}
+    engines: {node: '>=14.14'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -1869,6 +2300,9 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
+  tweetnacl@0.14.5:
+    resolution: {integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==}
+
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
@@ -1884,8 +2318,15 @@ packages:
   unconfig@7.3.2:
     resolution: {integrity: sha512-nqG5NNL2wFVGZ0NA/aCFw0oJ2pxSf1lwg4Z5ill8wd7K4KX/rQbHlwbh+bjctXL5Ly1xtzHenHGOK0b+lG6JVg==}
 
+  undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  undici@7.10.0:
+    resolution: {integrity: sha512-u5otvFBOBZvmdjWLVW+5DAc9Nkq8f24g0O9oY7qw2JVIF1VocIFoyz9JFkuVOS2j41AufeO0xnlweJ2RLT8nGw==}
+    engines: {node: '>=20.18.1'}
 
   unist-util-is@6.0.0:
     resolution: {integrity: sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==}
@@ -1910,6 +2351,10 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  uuid@10.0.0:
+    resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    hasBin: true
 
   vite-node@3.2.4:
     resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
@@ -2004,9 +2449,24 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
+  wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
   xml-name-validator@4.0.0:
     resolution: {integrity: sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==}
     engines: {node: '>=12'}
+
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
 
   yaml-eslint-parser@1.3.0:
     resolution: {integrity: sha512-E/+VitOorXSLiAqtTd7Yqax0/pAS3xaYMP+AUUJGOK1OZG3rhcj9fcJOM5HJ2VrP1FrStVCWr1muTfQCdj4tAA==}
@@ -2017,9 +2477,21 @@ packages:
     engines: {node: '>= 14.6'}
     hasBin: true
 
+  yargs-parser@21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+
+  yargs@17.7.2:
+    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
+    engines: {node: '>=12'}
+
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zip-stream@6.0.1:
+    resolution: {integrity: sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==}
+    engines: {node: '>= 14'}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -2051,6 +2523,8 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
+
+  '@balena/dockerignore@1.0.2': {}
 
   '@clack/core@0.5.0':
     dependencies:
@@ -2248,6 +2722,18 @@ snapshots:
       '@eslint/core': 0.15.0
       levn: 0.4.1
 
+  '@grpc/grpc-js@1.13.4':
+    dependencies:
+      '@grpc/proto-loader': 0.7.15
+      '@js-sdsl/ordered-map': 4.4.2
+
+  '@grpc/proto-loader@0.7.15':
+    dependencies:
+      lodash.camelcase: 4.3.0
+      long: 5.3.2
+      protobufjs: 7.5.3
+      yargs: 17.7.2
+
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.6':
@@ -2260,6 +2746,15 @@ snapshots:
   '@humanwhocodes/retry@0.3.1': {}
 
   '@humanwhocodes/retry@0.4.3': {}
+
+  '@isaacs/cliui@8.0.2':
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+      strip-ansi: 7.1.0
+      strip-ansi-cjs: strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: wrap-ansi@7.0.0
 
   '@jridgewell/gen-mapping@0.3.8':
     dependencies:
@@ -2277,6 +2772,8 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
+
+  '@js-sdsl/ordered-map@4.4.2': {}
 
   '@luxass/eslint-config@5.0.0(@vue/compiler-sfc@3.5.17)(eslint-plugin-format@1.0.1(eslint@9.29.0(jiti@2.4.2)))(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.15.32)(jiti@2.4.2)(yaml@2.8.0))':
     dependencies:
@@ -2345,9 +2842,35 @@ snapshots:
 
   '@oxc-project/types@0.72.3': {}
 
+  '@pkgjs/parseargs@0.11.0':
+    optional: true
+
   '@pkgr/core@0.1.2': {}
 
   '@pkgr/core@0.2.7': {}
+
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.4': {}
+
+  '@protobufjs/eventemitter@1.1.0': {}
+
+  '@protobufjs/fetch@1.1.0':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/inquire': 1.1.0
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/inquire@1.1.0': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.0': {}
 
   '@publint/pack@0.1.2': {}
 
@@ -2482,6 +3005,17 @@ snapshots:
 
   '@types/deep-eql@4.0.2': {}
 
+  '@types/docker-modem@3.0.6':
+    dependencies:
+      '@types/node': 22.15.32
+      '@types/ssh2': 1.15.5
+
+  '@types/dockerode@3.3.41':
+    dependencies:
+      '@types/docker-modem': 3.0.6
+      '@types/node': 22.15.32
+      '@types/ssh2': 1.15.5
+
   '@types/estree@1.0.8': {}
 
   '@types/json-schema@7.0.15': {}
@@ -2492,9 +3026,26 @@ snapshots:
 
   '@types/ms@2.1.0': {}
 
+  '@types/node@18.19.112':
+    dependencies:
+      undici-types: 5.26.5
+
   '@types/node@22.15.32':
     dependencies:
       undici-types: 6.21.0
+
+  '@types/ssh2-streams@0.1.12':
+    dependencies:
+      '@types/node': 22.15.32
+
+  '@types/ssh2@0.5.52':
+    dependencies:
+      '@types/node': 22.15.32
+      '@types/ssh2-streams': 0.1.12
+
+  '@types/ssh2@1.15.5':
+    dependencies:
+      '@types/node': 18.19.112
 
   '@types/unist@3.0.3': {}
 
@@ -2674,6 +3225,10 @@ snapshots:
 
   '@vue/shared@3.5.17': {}
 
+  abort-controller@3.0.0:
+    dependencies:
+      event-target-shim: 5.0.1
+
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
       acorn: 8.15.0
@@ -2687,15 +3242,45 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
+  ansi-regex@5.0.1: {}
+
+  ansi-regex@6.1.0: {}
+
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@6.2.1: {}
+
   ansis@4.1.0: {}
+
+  archiver-utils@5.0.2:
+    dependencies:
+      glob: 10.4.5
+      graceful-fs: 4.2.11
+      is-stream: 2.0.1
+      lazystream: 1.0.1
+      lodash: 4.17.21
+      normalize-path: 3.0.0
+      readable-stream: 4.7.0
+
+  archiver@7.0.1:
+    dependencies:
+      archiver-utils: 5.0.2
+      async: 3.2.6
+      buffer-crc32: 1.0.0
+      readable-stream: 4.7.0
+      readdir-glob: 1.1.3
+      tar-stream: 3.1.7
+      zip-stream: 6.0.1
 
   are-docs-informative@0.0.2: {}
 
   argparse@2.0.1: {}
+
+  asn1@0.2.6:
+    dependencies:
+      safer-buffer: 2.1.2
 
   assertion-error@2.0.1: {}
 
@@ -2704,9 +3289,52 @@ snapshots:
       '@babel/parser': 7.27.5
       pathe: 2.0.3
 
+  async-lock@1.4.1: {}
+
+  async@3.2.6: {}
+
+  b4a@1.6.7: {}
+
   balanced-match@1.0.2: {}
 
+  bare-events@2.5.4:
+    optional: true
+
+  bare-fs@4.1.5:
+    dependencies:
+      bare-events: 2.5.4
+      bare-path: 3.0.0
+      bare-stream: 2.6.5(bare-events@2.5.4)
+    optional: true
+
+  bare-os@3.6.1:
+    optional: true
+
+  bare-path@3.0.0:
+    dependencies:
+      bare-os: 3.6.1
+    optional: true
+
+  bare-stream@2.6.5(bare-events@2.5.4):
+    dependencies:
+      streamx: 2.22.1
+    optionalDependencies:
+      bare-events: 2.5.4
+    optional: true
+
+  base64-js@1.5.1: {}
+
+  bcrypt-pbkdf@1.0.2:
+    dependencies:
+      tweetnacl: 0.14.5
+
   birpc@2.4.0: {}
+
+  bl@4.1.0:
+    dependencies:
+      buffer: 5.7.1
+      inherits: 2.0.4
+      readable-stream: 3.6.2
 
   boolbase@1.0.0: {}
 
@@ -2730,7 +3358,24 @@ snapshots:
       node-releases: 2.0.19
       update-browserslist-db: 1.1.3(browserslist@4.25.0)
 
+  buffer-crc32@1.0.0: {}
+
+  buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
+  buffer@6.0.3:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
+  buildcheck@0.0.6:
+    optional: true
+
   builtin-modules@5.0.0: {}
+
+  byline@5.0.0: {}
 
   cac@6.7.14: {}
 
@@ -2761,11 +3406,19 @@ snapshots:
     dependencies:
       readdirp: 4.1.2
 
+  chownr@1.1.4: {}
+
   ci-info@4.2.0: {}
 
   clean-regexp@1.0.0:
     dependencies:
       escape-string-regexp: 1.0.5
+
+  cliui@8.0.1:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
 
   color-convert@2.0.1:
     dependencies:
@@ -2774,6 +3427,14 @@ snapshots:
   color-name@1.1.4: {}
 
   comment-parser@1.4.1: {}
+
+  compress-commons@6.0.2:
+    dependencies:
+      crc-32: 1.2.2
+      crc32-stream: 6.0.0
+      is-stream: 2.0.1
+      normalize-path: 3.0.0
+      readable-stream: 4.7.0
 
   concat-map@0.0.1: {}
 
@@ -2784,6 +3445,21 @@ snapshots:
   core-js-compat@3.43.0:
     dependencies:
       browserslist: 4.25.0
+
+  core-util-is@1.0.3: {}
+
+  cpu-features@0.0.10:
+    dependencies:
+      buildcheck: 0.0.6
+      nan: 2.22.2
+    optional: true
+
+  crc-32@1.2.2: {}
+
+  crc32-stream@6.0.0:
+    dependencies:
+      crc-32: 1.2.2
+      readable-stream: 4.7.0
 
   cross-spawn@7.0.6:
     dependencies:
@@ -2825,6 +3501,31 @@ snapshots:
 
   diff@8.0.2: {}
 
+  docker-compose@1.2.0:
+    dependencies:
+      yaml: 2.8.0
+
+  docker-modem@5.0.6:
+    dependencies:
+      debug: 4.4.1
+      readable-stream: 3.6.2
+      split-ca: 1.0.1
+      ssh2: 1.16.0
+    transitivePeerDependencies:
+      - supports-color
+
+  dockerode@4.0.7:
+    dependencies:
+      '@balena/dockerignore': 1.0.2
+      '@grpc/grpc-js': 1.13.4
+      '@grpc/proto-loader': 0.7.15
+      docker-modem: 5.0.6
+      protobufjs: 7.5.3
+      tar-fs: 2.1.3
+      uuid: 10.0.0
+    transitivePeerDependencies:
+      - supports-color
+
   dom-serializer@2.0.0:
     dependencies:
       domelementtype: 2.3.0
@@ -2845,9 +3546,19 @@ snapshots:
 
   dts-resolver@2.1.1: {}
 
+  eastasianwidth@0.2.0: {}
+
   electron-to-chromium@1.5.171: {}
 
+  emoji-regex@8.0.0: {}
+
+  emoji-regex@9.2.2: {}
+
   empathic@1.1.0: {}
+
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
 
   enhanced-resolve@5.18.1:
     dependencies:
@@ -3183,6 +3894,10 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  event-target-shim@5.0.1: {}
+
+  events@3.3.0: {}
+
   expect-type@1.2.1: {}
 
   exsolve@1.0.7: {}
@@ -3190,6 +3905,8 @@ snapshots:
   fast-deep-equal@3.1.3: {}
 
   fast-diff@1.3.0: {}
+
+  fast-fifo@1.3.2: {}
 
   fast-glob@3.3.3:
     dependencies:
@@ -3237,10 +3954,21 @@ snapshots:
 
   flatted@3.3.3: {}
 
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
   format@0.2.2: {}
+
+  fs-constants@1.0.0: {}
 
   fsevents@2.3.3:
     optional: true
+
+  get-caller-file@2.0.5: {}
+
+  get-port@7.1.0: {}
 
   get-tsconfig@4.10.1:
     dependencies:
@@ -3255,6 +3983,15 @@ snapshots:
   glob-parent@6.0.2:
     dependencies:
       is-glob: 4.0.3
+
+  glob@10.4.5:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 3.4.3
+      minimatch: 9.0.5
+      minipass: 7.1.2
+      package-json-from-dist: 1.0.1
+      path-scurry: 1.11.1
 
   globals@14.0.0: {}
 
@@ -3272,6 +4009,8 @@ snapshots:
 
   hookable@5.5.3: {}
 
+  ieee754@1.2.1: {}
+
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
@@ -3285,11 +4024,15 @@ snapshots:
 
   indent-string@5.0.0: {}
 
+  inherits@2.0.4: {}
+
   is-builtin-module@5.0.0:
     dependencies:
       builtin-modules: 5.0.0
 
   is-extglob@2.1.1: {}
+
+  is-fullwidth-code-point@3.0.0: {}
 
   is-glob@4.0.3:
     dependencies:
@@ -3297,7 +4040,17 @@ snapshots:
 
   is-number@7.0.0: {}
 
+  is-stream@2.0.1: {}
+
+  isarray@1.0.0: {}
+
   isexe@2.0.0: {}
+
+  jackspeak@3.4.3:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
 
   jiti@2.4.2: {}
 
@@ -3330,6 +4083,10 @@ snapshots:
     dependencies:
       json-buffer: 3.0.1
 
+  lazystream@1.0.1:
+    dependencies:
+      readable-stream: 2.3.8
+
   levn@0.4.1:
     dependencies:
       prelude-ls: 1.2.1
@@ -3345,13 +4102,19 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
+  lodash.camelcase@4.3.0: {}
+
   lodash.merge@4.6.2: {}
 
   lodash@4.17.21: {}
 
+  long@5.3.2: {}
+
   longest-streak@3.1.0: {}
 
   loupe@3.1.4: {}
+
+  lru-cache@10.4.3: {}
 
   magic-string@0.30.17:
     dependencies:
@@ -3683,9 +4446,19 @@ snapshots:
     dependencies:
       brace-expansion: 1.1.12
 
+  minimatch@5.1.6:
+    dependencies:
+      brace-expansion: 2.0.2
+
   minimatch@9.0.5:
     dependencies:
       brace-expansion: 2.0.2
+
+  minipass@7.1.2: {}
+
+  mkdirp-classic@0.5.3: {}
+
+  mkdirp@1.0.4: {}
 
   mlly@1.7.4:
     dependencies:
@@ -3697,6 +4470,9 @@ snapshots:
   mri@1.2.0: {}
 
   ms@2.1.3: {}
+
+  nan@2.22.2:
+    optional: true
 
   nanoid@3.3.11: {}
 
@@ -3711,9 +4487,15 @@ snapshots:
 
   node-releases@2.0.19: {}
 
+  normalize-path@3.0.0: {}
+
   nth-check@2.1.1:
     dependencies:
       boolbase: 1.0.0
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
 
   optionator@0.9.4:
     dependencies:
@@ -3732,6 +4514,8 @@ snapshots:
     dependencies:
       p-limit: 3.1.0
 
+  package-json-from-dist@1.0.1: {}
+
   package-manager-detector@1.3.0: {}
 
   parent-module@1.0.1:
@@ -3749,6 +4533,11 @@ snapshots:
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
+
+  path-scurry@1.11.1:
+    dependencies:
+      lru-cache: 10.4.3
+      minipass: 7.1.2
 
   pathe@2.0.3: {}
 
@@ -3797,6 +4586,35 @@ snapshots:
 
   prettier@3.5.3: {}
 
+  process-nextick-args@2.0.1: {}
+
+  process@0.11.10: {}
+
+  proper-lockfile@4.1.2:
+    dependencies:
+      graceful-fs: 4.2.11
+      retry: 0.12.0
+      signal-exit: 3.0.7
+
+  properties-reader@2.3.0:
+    dependencies:
+      mkdirp: 1.0.4
+
+  protobufjs@7.5.3:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.4
+      '@protobufjs/eventemitter': 1.1.0
+      '@protobufjs/fetch': 1.1.0
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/inquire': 1.1.0
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.0
+      '@types/node': 22.15.32
+      long: 5.3.2
+
   publint@0.3.12:
     dependencies:
       '@publint/pack': 0.1.2
@@ -3804,11 +4622,44 @@ snapshots:
       picocolors: 1.1.1
       sade: 1.8.1
 
+  pump@3.0.3:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
+
   punycode@2.3.1: {}
 
   quansync@0.2.10: {}
 
   queue-microtask@1.2.3: {}
+
+  readable-stream@2.3.8:
+    dependencies:
+      core-util-is: 1.0.3
+      inherits: 2.0.4
+      isarray: 1.0.0
+      process-nextick-args: 2.0.1
+      safe-buffer: 5.1.2
+      string_decoder: 1.1.1
+      util-deprecate: 1.0.2
+
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
+
+  readable-stream@4.7.0:
+    dependencies:
+      abort-controller: 3.0.0
+      buffer: 6.0.3
+      events: 3.3.0
+      process: 0.11.10
+      string_decoder: 1.3.0
+
+  readdir-glob@1.1.3:
+    dependencies:
+      minimatch: 5.1.6
 
   readdirp@4.1.2: {}
 
@@ -3827,9 +4678,13 @@ snapshots:
     dependencies:
       jsesc: 3.0.2
 
+  require-directory@2.1.1: {}
+
   resolve-from@4.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
+
+  retry@0.12.0: {}
 
   reusify@1.1.0: {}
 
@@ -3904,6 +4759,12 @@ snapshots:
     dependencies:
       mri: 1.2.0
 
+  safe-buffer@5.1.2: {}
+
+  safe-buffer@5.2.1: {}
+
+  safer-buffer@2.1.2: {}
+
   scslre@0.3.0:
     dependencies:
       '@eslint-community/regexpp': 4.12.1
@@ -3920,6 +4781,10 @@ snapshots:
 
   siginfo@2.0.0: {}
 
+  signal-exit@3.0.7: {}
+
+  signal-exit@4.1.0: {}
+
   sisteransi@1.0.5: {}
 
   source-map-js@1.2.1: {}
@@ -3933,9 +4798,59 @@ snapshots:
 
   spdx-license-ids@3.0.21: {}
 
+  split-ca@1.0.1: {}
+
+  ssh-remote-port-forward@1.0.4:
+    dependencies:
+      '@types/ssh2': 0.5.52
+      ssh2: 1.16.0
+
+  ssh2@1.16.0:
+    dependencies:
+      asn1: 0.2.6
+      bcrypt-pbkdf: 1.0.2
+    optionalDependencies:
+      cpu-features: 0.0.10
+      nan: 2.22.2
+
   stackback@0.0.2: {}
 
   std-env@3.9.0: {}
+
+  streamx@2.22.1:
+    dependencies:
+      fast-fifo: 1.3.2
+      text-decoder: 1.2.3
+    optionalDependencies:
+      bare-events: 2.5.4
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  string-width@5.1.2:
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.1.0
+
+  string_decoder@1.1.1:
+    dependencies:
+      safe-buffer: 5.1.2
+
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
+  strip-ansi@7.1.0:
+    dependencies:
+      ansi-regex: 6.1.0
 
   strip-indent@4.0.0:
     dependencies:
@@ -3962,6 +4877,62 @@ snapshots:
 
   tapable@2.2.2: {}
 
+  tar-fs@2.1.3:
+    dependencies:
+      chownr: 1.1.4
+      mkdirp-classic: 0.5.3
+      pump: 3.0.3
+      tar-stream: 2.2.0
+
+  tar-fs@3.0.10:
+    dependencies:
+      pump: 3.0.3
+      tar-stream: 3.1.7
+    optionalDependencies:
+      bare-fs: 4.1.5
+      bare-path: 3.0.0
+    transitivePeerDependencies:
+      - bare-buffer
+
+  tar-stream@2.2.0:
+    dependencies:
+      bl: 4.1.0
+      end-of-stream: 1.4.5
+      fs-constants: 1.0.0
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
+  tar-stream@3.1.7:
+    dependencies:
+      b4a: 1.6.7
+      fast-fifo: 1.3.2
+      streamx: 2.22.1
+
+  testcontainers@11.0.3:
+    dependencies:
+      '@balena/dockerignore': 1.0.2
+      '@types/dockerode': 3.3.41
+      archiver: 7.0.1
+      async-lock: 1.4.1
+      byline: 5.0.0
+      debug: 4.4.1
+      docker-compose: 1.2.0
+      dockerode: 4.0.7
+      get-port: 7.1.0
+      proper-lockfile: 4.1.2
+      properties-reader: 2.3.0
+      ssh-remote-port-forward: 1.0.4
+      tar-fs: 3.0.10
+      tmp: 0.2.3
+      undici: 7.10.0
+    transitivePeerDependencies:
+      - bare-buffer
+      - supports-color
+
+  text-decoder@1.2.3:
+    dependencies:
+      b4a: 1.6.7
+
   tinybench@2.9.0: {}
 
   tinyexec@0.3.2: {}
@@ -3978,6 +4949,8 @@ snapshots:
   tinyrainbow@2.0.0: {}
 
   tinyspy@4.0.3: {}
+
+  tmp@0.2.3: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -4022,6 +4995,8 @@ snapshots:
 
   tslib@2.8.1: {}
 
+  tweetnacl@0.14.5: {}
+
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
@@ -4037,7 +5012,11 @@ snapshots:
       jiti: 2.4.2
       quansync: 0.2.10
 
+  undici-types@5.26.5: {}
+
   undici-types@6.21.0: {}
+
+  undici@7.10.0: {}
 
   unist-util-is@6.0.0:
     dependencies:
@@ -4069,6 +5048,8 @@ snapshots:
       punycode: 2.3.1
 
   util-deprecate@1.0.2: {}
+
+  uuid@10.0.0: {}
 
   vite-node@3.2.4(@types/node@22.15.32)(jiti@2.4.2)(yaml@2.8.0):
     dependencies:
@@ -4171,7 +5152,23 @@ snapshots:
 
   word-wrap@1.2.5: {}
 
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  wrap-ansi@8.1.0:
+    dependencies:
+      ansi-styles: 6.2.1
+      string-width: 5.1.2
+      strip-ansi: 7.1.0
+
+  wrappy@1.0.2: {}
+
   xml-name-validator@4.0.0: {}
+
+  y18n@5.0.8: {}
 
   yaml-eslint-parser@1.3.0:
     dependencies:
@@ -4180,6 +5177,24 @@ snapshots:
 
   yaml@2.8.0: {}
 
+  yargs-parser@21.1.1: {}
+
+  yargs@17.7.2:
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
+
   yocto-queue@0.1.0: {}
+
+  zip-stream@6.0.1:
+    dependencies:
+      archiver-utils: 5.0.2
+      compress-commons: 6.0.2
+      readable-stream: 4.7.0
 
   zwitch@2.0.4: {}

--- a/src/index.ts
+++ b/src/index.ts
@@ -194,99 +194,58 @@ function parseF0(html: HTMLElement): Entry[] {
 function parseF1(html: HTMLElement): Entry[] {
   const entries: Entry[] = [];
 
-  const preElements = html.querySelectorAll("pre");
-  if (preElements.length === 0) return entries;
+  const preElement = html.querySelector("pre");
+  if (!preElement) return entries;
+  const root = __parse(preElement.textContent);
 
-  for (const pre of preElements) {
-    const preContent = pre.textContent || "";
+  // Find all the links in the pre content
+  const links = root.querySelectorAll("a");
 
-    // split content by lines to process each entry
-    const lines = preContent.split("\n");
+  for (const link of links) {
+    const href = link.getAttribute("href") || "";
+    const name = link.textContent.trim();
 
-    for (const line of lines) {
-      // skip header lines, hr tags, and empty lines
-      if (line.includes("<hr>") || line.trim() === "") {
-        continue;
+    // Skip parent directory and sort links
+    if (name === "Parent Directory" || href.startsWith("?")) {
+      continue;
+    }
+
+    // Determine if it's a directory or file
+    const isDirectory = href.endsWith("/");
+    const type = isDirectory ? "directory" : "file";
+
+    // Get the parent element to extract additional info
+    const parentText = link.parentNode?.textContent || "";
+
+    // Extract date and time using regex
+    let lastModified;
+    const dateMatch = parentText.match(/(\d{2}-\w{3}-\d{4}\s+\d{2}:\d{2}|\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2})/);
+    if (dateMatch && dateMatch[0]) {
+      const dateString = dateMatch[0];
+      const date = new Date(dateString);
+      if (!Number.isNaN(date.getTime())) {
+        lastModified = date.getTime();
       }
+    }
 
-      // skip lines that are only header links (contain sorting links but no file links)
-      if (line.includes("Last modified") && line.includes("?C=") && !line.match(/<a[^>]+href=["'](?!\?)[^"']+["'][^>]*>/)) {
-        continue;
-      }
+    // Clean up directory name if it ends with /
+    const cleanName = isDirectory && name.endsWith("/") ? name.slice(0, -1) : name;
 
-      // check if this line contains links (but not sorting links)
-      const linkMatches = line.matchAll(/<a[^>]+href=["']([^"']+)["'][^>]*>(.*?)<\/a>/gi);
-
-      for (const linkMatch of linkMatches) {
-        const href = linkMatch[1] || "";
-        const linkText = (linkMatch[2] || "").trim();
-
-        // skip sorting links (those that start with ?)
-        if (href.startsWith("?")) continue;
-
-        // skip parent directory link
-        if (linkText === "Parent Directory" || href === "/") continue;
-
-        // determine if this is a directory or file
-        // Check for img tag with alt attribute first
-        let type: "directory" | "file" = "file";
-        const imgMatch = line.match(/<img[^>]+alt=["'](\[[^\]]+\])["'][^>]*>/i);
-
-        if (imgMatch) {
-          // has image - use alt attribute to determine type
-          const imgAlt = imgMatch[1];
-          type = imgAlt === "[DIR]" ? "directory" : "file";
-        } else {
-          // no image - determine by href ending with /
-          type = href.endsWith("/") ? "directory" : "file";
-        }
-
-        // extract date from the line content
-        const dateMatch = line.match(/\d{4}-\d{2}-\d{2} \d{2}:\d{2}/);
-        let lastModified;
-        if (dateMatch && dateMatch[0]) {
-          const dateString = dateMatch[0];
-          const date = new Date(`${dateString.replace(" ", "T")}:00Z`);
-          if (!Number.isNaN(date.getTime())) {
-            lastModified = date.getTime();
-          }
-        }
-
-        // clean up the name - remove trailing / for directories and decode HTML entities
-        let name = linkText;
-        if (type === "directory" && name.endsWith("/")) {
-          name = name.slice(0, -1);
-        }
-
-        // handle truncated names (ending with ..>)
-        if (name.endsWith("..>")) {
-          // try to extract the full name from href
-          const decodedHref = decodeURIComponent(href);
-          if (decodedHref !== href) {
-            // use the decoded href as the name (removing extension or trailing /)
-            name = decodedHref.replace(/\/$/, "").split("/").pop() || name;
-          }
-        }
-
-        const path = href;
-
-        if (type === "directory") {
-          entries.push({
-            type,
-            name,
-            path,
-            lastModified,
-            children: [],
-          });
-        } else {
-          entries.push({
-            type,
-            name,
-            path,
-            lastModified,
-          });
-        }
-      }
+    if (type === "directory") {
+      entries.push({
+        type,
+        name: cleanName,
+        path: href,
+        lastModified,
+        children: [],
+      });
+    } else {
+      entries.push({
+        type,
+        name: cleanName,
+        path: href,
+        lastModified,
+      });
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -133,14 +133,14 @@ export function inferFormat(html: string | HTMLElement): AutoIndexFormat {
     if (formatMatch && formatMatch[1]) {
       return `F${formatMatch[1]}` as AutoIndexFormat;
     }
+  }
 
-    if (hasPre) {
-      return "F1";
-    }
+  if (hasPre) {
+    return "F1";
+  }
 
-    if (hasTable) {
-      return "F2";
-    }
+  if (hasTable) {
+    return "F2";
   }
 
   return "F0";

--- a/src/index.ts
+++ b/src/index.ts
@@ -96,6 +96,10 @@ export function inferFormat(html: string | HTMLElement): AutoIndexFormat {
   const hrefs = [];
 
   const pre = html.querySelector("pre");
+
+  const hasPre = pre !== null;
+  const hasTable = html.querySelector("table") !== null;
+
   // F1 is the only format that uses <pre> tags for wrapping the links
   // which breaks the parsing logic of 'node-html-parser'
   // so we need to handle it separately
@@ -128,6 +132,14 @@ export function inferFormat(html: string | HTMLElement): AutoIndexFormat {
     const formatMatch = href.match(/F=(\d)/);
     if (formatMatch && formatMatch[1]) {
       return `F${formatMatch[1]}` as AutoIndexFormat;
+    }
+
+    if (hasPre) {
+      return "F1";
+    }
+
+    if (hasTable) {
+      return "F2";
     }
   }
 

--- a/test/configs/apache-fancy.conf
+++ b/test/configs/apache-fancy.conf
@@ -1,7 +1,3 @@
-# Apache 2.4 configuration with fancy indexing (F2)
-ServerRoot "/usr/local/apache2"
-Listen 80
-
 # Load required modules 2.4 configuration with HTMLTable format (F2)
 ServerRoot "/usr/local/apache2"
 Listen 80

--- a/test/configs/apache-fancy.conf
+++ b/test/configs/apache-fancy.conf
@@ -1,4 +1,8 @@
-# Apache 2.4 configuration with HTMLTable format (F2)
+# Apache 2.4 configuration with fancy indexing (F2)
+ServerRoot "/usr/local/apache2"
+Listen 80
+
+# Load required modules 2.4 configuration with HTMLTable format (F2)
 ServerRoot "/usr/local/apache2"
 Listen 80
 

--- a/test/configs/apache-fancy.conf
+++ b/test/configs/apache-fancy.conf
@@ -1,0 +1,55 @@
+# Apache 2.4 configuration with HTMLTable format (F2)
+ServerRoot "/usr/local/apache2"
+Listen 80
+
+# Load required modules
+LoadModule mpm_event_module modules/mod_mpm_event.so
+LoadModule authz_core_module modules/mod_authz_core.so
+LoadModule dir_module modules/mod_dir.so
+LoadModule mime_module modules/mod_mime.so
+LoadModule autoindex_module modules/mod_autoindex.so
+LoadModule unixd_module modules/mod_unixd.so
+LoadModule log_config_module modules/mod_log_config.so
+
+# Basic settings
+ServerName localhost
+User www-data
+Group www-data
+
+# MIME types
+TypesConfig conf/mime.types
+
+# Document root
+DocumentRoot "/usr/local/apache2/htdocs"
+
+# Directory configuration for HTMLTable format (F2)
+<Directory "/usr/local/apache2/htdocs">
+    Options Indexes FollowSymLinks
+    AllowOverride None
+    Require all granted
+
+    # Enable fancy indexing with HTML table
+    IndexOptions FancyIndexing HTMLTable IconsAreLinks VersionSort
+    IndexOptions +NameWidth=* +DescriptionWidth=*
+    IndexOrderDefault Ascending Name
+
+    # Add descriptions for file types
+    AddDescription "HTML Document" *.html *.htm
+    AddDescription "Text Document" *.txt
+    AddDescription "JavaScript" *.js
+    AddDescription "CSS Stylesheet" *.css
+    AddDescription "JSON Data" *.json
+    AddDescription "XML Document" *.xml
+    AddDescription "Markdown" *.md
+    AddDescription "Log File" *.log
+    AddDescription "Directory" ^^DIRECTORY^^
+</Directory>
+
+# Logging
+ErrorLog /proc/self/fd/2
+CustomLog /proc/self/fd/1 common
+
+# Security
+<Files ".ht*">
+    Require all denied
+</Files>

--- a/test/configs/apache-pre.conf
+++ b/test/configs/apache-pre.conf
@@ -1,0 +1,55 @@
+# Apache 2.4 configuration with pre-formatted output (F1)
+ServerRoot "/usr/local/apache2"
+Listen 80
+
+# Load required modules
+LoadModule mpm_event_module modules/mod_mpm_event.so
+LoadModule authz_core_module modules/mod_authz_core.so
+LoadModule dir_module modules/mod_dir.so
+LoadModule mime_module modules/mod_mime.so
+LoadModule autoindex_module modules/mod_autoindex.so
+LoadModule unixd_module modules/mod_unixd.so
+LoadModule log_config_module modules/mod_log_config.so
+
+# Basic settings
+ServerName localhost
+User www-data
+Group www-data
+
+# MIME types
+TypesConfig conf/mime.types
+
+# Document root
+DocumentRoot "/usr/local/apache2/htdocs"
+
+# Directory configuration for pre-formatted output (F1)
+<Directory "/usr/local/apache2/htdocs">
+    Options Indexes FollowSymLinks
+    AllowOverride None
+    Require all granted
+
+    # Enable fancy indexing but without HTML table (uses <pre> format)
+    IndexOptions FancyIndexing -HTMLTable IconsAreLinks VersionSort
+    IndexOptions +NameWidth=* +DescriptionWidth=*
+    IndexOrderDefault Ascending Name
+
+    # Add descriptions for file types
+    AddDescription "HTML Document" *.html *.htm
+    AddDescription "Text Document" *.txt
+    AddDescription "JavaScript" *.js
+    AddDescription "CSS Stylesheet" *.css
+    AddDescription "JSON Data" *.json
+    AddDescription "XML Document" *.xml
+    AddDescription "Markdown" *.md
+    AddDescription "Log File" *.log
+    AddDescription "Directory" ^^DIRECTORY^^
+</Directory>
+
+# Logging
+ErrorLog /proc/self/fd/2
+CustomLog /proc/self/fd/1 common
+
+# Security
+<Files ".ht*">
+    Require all denied
+</Files>

--- a/test/configs/apache-simple.conf
+++ b/test/configs/apache-simple.conf
@@ -1,7 +1,3 @@
-# Apache 2.4 configuration with simple output (F0)
-ServerRoot "/usr/local/apache2"
-Listen 80
-
 # Load required modules 2.4 configuration with simple format (F0)
 ServerRoot "/usr/local/apache2"
 Listen 80

--- a/test/configs/apache-simple.conf
+++ b/test/configs/apache-simple.conf
@@ -1,4 +1,8 @@
-# Apache 2.4 configuration with simple format (F0)
+# Apache 2.4 configuration with simple output (F0)
+ServerRoot "/usr/local/apache2"
+Listen 80
+
+# Load required modules 2.4 configuration with simple format (F0)
 ServerRoot "/usr/local/apache2"
 Listen 80
 

--- a/test/configs/apache-simple.conf
+++ b/test/configs/apache-simple.conf
@@ -1,0 +1,44 @@
+# Apache 2.4 configuration with simple format (F0)
+ServerRoot "/usr/local/apache2"
+Listen 80
+
+# Load required modules
+LoadModule mpm_event_module modules/mod_mpm_event.so
+LoadModule authz_core_module modules/mod_authz_core.so
+LoadModule dir_module modules/mod_dir.so
+LoadModule mime_module modules/mod_mime.so
+LoadModule autoindex_module modules/mod_autoindex.so
+LoadModule unixd_module modules/mod_unixd.so
+LoadModule log_config_module modules/mod_log_config.so
+
+# Basic settings
+ServerName localhost
+User www-data
+Group www-data
+
+# MIME types
+TypesConfig conf/mime.types
+
+# Document root
+DocumentRoot "/usr/local/apache2/htdocs"
+
+# Directory configuration for simple format (F0)
+<Directory "/usr/local/apache2/htdocs">
+    Options Indexes FollowSymLinks
+    AllowOverride None
+    Require all granted
+
+    # Disable fancy indexing for simple format
+    IndexOptions -FancyIndexing -HTMLTable
+    IndexOptions SuppressIcon SuppressSize SuppressLastModified SuppressDescription
+    IndexOrderDefault Ascending Name
+</Directory>
+
+# Logging
+ErrorLog /proc/self/fd/2
+CustomLog /proc/self/fd/1 common
+
+# Security
+<Files ".ht*">
+    Require all denied
+</Files>

--- a/test/f1.test.ts
+++ b/test/f1.test.ts
@@ -109,7 +109,7 @@ describe("F1", () => {
     ]);
   });
 
-  it.todo("parse special files", () => {
+  it("parse special files", () => {
     const html = readFileSync(fixture("special-files.html"), "utf-8");
 
     const entry = parse(html, "F1");
@@ -125,8 +125,8 @@ describe("F1", () => {
       "file%22with%22double%22quotes.rb",
       "file%23with%23hash.py",
       "file%2520with%2520url%2520encoding.html",
-      "file&with&ampersands.php",
-      "file",
+      "file&with&ersands.php",
+      "file'with'quotes.sh",
       "file(with)parentheses.txt",
       "file+with+plus+signs.txt",
       "file,with,commas.csv",

--- a/test/f2.test.ts
+++ b/test/f2.test.ts
@@ -90,7 +90,7 @@ describe("F2", () => {
     ]);
   });
 
-  it.todo("parse directory", () => {
+  it("parse directory", () => {
     const html = readFileSync(fixture("directory.html"), "utf-8");
 
     const entry = parse(html, "F2");
@@ -109,7 +109,7 @@ describe("F2", () => {
     ]);
   });
 
-  it.todo("parse special files", () => {
+  it("parse special files", () => {
     const html = readFileSync(fixture("special-files.html"), "utf-8");
 
     const entry = parse(html, "F2");
@@ -125,8 +125,8 @@ describe("F2", () => {
       "file%22with%22double%22quotes.rb",
       "file%23with%23hash.py",
       "file%2520with%2520url%2520encoding.html",
-      "file&amp;with&amp;ampersands.php",
-      "file",
+      "file&with&ersands.php",
+      "file'with'quotes.sh",
       "file(with)parentheses.txt",
       "file+with+plus+signs.txt",
       "file,with,commas.csv",

--- a/test/f2.test.ts
+++ b/test/f2.test.ts
@@ -125,7 +125,7 @@ describe("F2", () => {
       "file%22with%22double%22quotes.rb",
       "file%23with%23hash.py",
       "file%2520with%2520url%2520encoding.html",
-      "file&with&ersands.php",
+      "file&with&ampersands.php",
       "file'with'quotes.sh",
       "file(with)parentheses.txt",
       "file+with+plus+signs.txt",

--- a/test/integrations/apache-custom-config.integration.test.ts
+++ b/test/integrations/apache-custom-config.integration.test.ts
@@ -36,8 +36,21 @@ describe("Apache Custom Config Integration Test", async () => {
   });
 
   beforeAll(async () => {
+    const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
     apacheContainer = await new GenericContainer("httpd:2.4-alpine")
       .withExposedPorts(80)
+      .withCommand([
+        "sh",
+        "-c",
+        `apk add --no-cache tzdata && `
+        + `ln -snf /usr/share/zoneinfo/${timezone} /etc/localtime && `
+        + `echo "${timezone}" > /etc/timezone && `
+        + `exec httpd-foreground`,
+      ])
+      .withEnvironment({
+        TZ: timezone,
+      })
       .withBindMounts([
         {
           source: path.resolve("./test/configs/apache-fancy.conf"),

--- a/test/integrations/apache-custom-config.integration.test.ts
+++ b/test/integrations/apache-custom-config.integration.test.ts
@@ -119,7 +119,7 @@ describe("Apache Custom Config Integration Test", async () => {
 
     expect(parsed).toBeDefined();
     expect(parsed?.type).toBe("directory");
-    expect(parsed?.path).toBe("/nested/");
+    expect(parsed?.path).toBe("/nested");
 
     const children = parsed?.children || [];
     expect(children.length).toBeGreaterThan(0);
@@ -131,7 +131,7 @@ describe("Apache Custom Config Integration Test", async () => {
   });
 
   it("should handle unicode filenames", async () => {
-    const response = await fetch(getContainerUrl("nested/special%20chars/"));
+    const response = await fetch(getContainerUrl("/nested/special%20chars/"));
     expect(response.status).toBe(200);
 
     const html = await response.text();

--- a/test/integrations/apache-custom-config.integration.test.ts
+++ b/test/integrations/apache-custom-config.integration.test.ts
@@ -30,9 +30,12 @@ describe("Apache Custom Config Integration Test", async () => {
         },
       },
     },
-    "many-files": Array.from({ length: 10 }, (_, i) => ({
-      [`file-${String(i + 1).padStart(3, "0")}.txt`]: `Content of file ${i + 1}`,
-    })).reduce((acc, obj) => ({ ...acc, ...obj }), {}),
+    "many-files": Object.fromEntries(
+      Array.from({ length: 10 }, (_, i) => [
+        `file-${String(i + 1).padStart(3, "0")}.txt`,
+        `Content of file ${i + 1}`,
+      ]),
+    ),
   });
 
   beforeAll(async () => {

--- a/test/integrations/apache-custom-config.integration.test.ts
+++ b/test/integrations/apache-custom-config.integration.test.ts
@@ -1,0 +1,211 @@
+import type { StartedTestContainer } from "testcontainers";
+import path from "node:path";
+import { GenericContainer } from "testcontainers";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { testdir } from "vitest-testdirs";
+import { inferFormat, parse } from "../../src";
+
+// eslint-disable-next-line test/prefer-lowercase-title
+describe("Apache Custom Config Integration Test", async () => {
+  let apacheContainer: StartedTestContainer;
+  const testdirPath = await testdir({
+    "ReadMe.txt": "This is a test directory for Apache integration tests.",
+    "normal-file.html": "<h1>Normal File</h1>",
+    "file with spaces.txt": "File with spaces in name",
+    "file-with-dashes.css": "/* CSS file */",
+    "file_with_underscores.js": "// JavaScript file",
+    "file.with.dots.json": "{\"test\": true}",
+    "UPPERCASE-FILE.XML": "<?xml version='1.0'?>",
+    "file(with)parentheses.log": "Log file content",
+    "file[with]brackets.md": "# Markdown file",
+    "nested": {
+      "nestedFile.txt": "This is a nested file.",
+      "special chars": {
+        "файл.txt": "Unicode filename",
+        "中文文件.txt": "Chinese filename",
+      },
+      "deep": {
+        level: {
+          "deepFile.txt": "Deep nested file",
+        },
+      },
+    },
+    "many-files": Array.from({ length: 10 }, (_, i) => ({
+      [`file-${String(i + 1).padStart(3, "0")}.txt`]: `Content of file ${i + 1}`,
+    })).reduce((acc, obj) => ({ ...acc, ...obj }), {}),
+  });
+
+  beforeAll(async () => {
+    apacheContainer = await new GenericContainer("httpd:2.4-alpine")
+      .withExposedPorts(80)
+      .withBindMounts([
+        {
+          source: path.resolve("./test/configs/apache-fancy.conf"),
+          target: "/usr/local/apache2/conf/httpd.conf",
+        },
+        {
+          source: testdirPath,
+          target: "/usr/local/apache2/htdocs",
+        },
+      ])
+      .start();
+  });
+
+  afterAll(async () => {
+    await apacheContainer.stop();
+  });
+
+  function getContainerUrl(path = "/") {
+    const port = apacheContainer.getMappedPort(80);
+    const host = apacheContainer.getHost();
+    return `http://${host}:${port}${path}`;
+  }
+
+  it("should start container successfully", async () => {
+    const response = await fetch(getContainerUrl());
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("text/html");
+  });
+
+  it("should infer fancy format (F2)", async () => {
+    const response = await fetch(getContainerUrl());
+    const html = await response.text();
+    const inferredFormat = inferFormat(html);
+
+    expect(inferredFormat).toBe("F2");
+  });
+
+  it("should parse root directory correctly", async () => {
+    const response = await fetch(getContainerUrl());
+    const html = await response.text();
+    const parsed = parse(html);
+
+    expect(parsed).toBeDefined();
+    expect(parsed?.type).toBe("directory");
+    expect(parsed?.path).toBe("/");
+    expect(parsed?.children).toBeDefined();
+
+    const children = parsed?.children || [];
+    expect(children.length).toBeGreaterThan(5);
+
+    // Check for expected files
+    const fileNames = children.map((child) => child.name);
+    expect(fileNames).toContain("ReadMe.txt");
+    expect(fileNames).toContain("normal-file.html");
+    expect(fileNames).toContain("nested");
+    expect(fileNames).toContain("many-files");
+  });
+
+  it("should handle files with special characters", async () => {
+    const response = await fetch(getContainerUrl());
+    const html = await response.text();
+    const parsed = parse(html);
+
+    const fileNames = parsed?.children.map((c) => c.name) || [];
+    expect(fileNames).toContain("file with spaces.txt");
+    expect(fileNames).toContain("file-with-dashes.css");
+    expect(fileNames).toContain("file_with_underscores.js");
+    expect(fileNames).toContain("file.with.dots.json");
+    expect(fileNames).toContain("file(with)parentheses.log");
+    expect(fileNames).toContain("file[with]brackets.md");
+  });
+
+  it("should parse nested directories", async () => {
+    const response = await fetch(getContainerUrl("/nested/"));
+    expect(response.status).toBe(200);
+
+    const html = await response.text();
+    const parsed = parse(html);
+
+    expect(parsed).toBeDefined();
+    expect(parsed?.type).toBe("directory");
+    expect(parsed?.path).toBe("/nested/");
+
+    const children = parsed?.children || [];
+    expect(children.length).toBeGreaterThan(0);
+
+    const childNames = children.map((c) => c.name);
+    expect(childNames).toContain("nestedFile.txt");
+    expect(childNames).toContain("special chars");
+    expect(childNames).toContain("deep");
+  });
+
+  it("should handle unicode filenames", async () => {
+    const response = await fetch(getContainerUrl("nested/special%20chars/"));
+    expect(response.status).toBe(200);
+
+    const html = await response.text();
+    const parsed = parse(html);
+
+    const children = parsed?.children || [];
+    const fileNames = children.map((c) => c.name);
+
+    // Unicode filenames should be parsed correctly
+    expect(fileNames.some((name) => name.includes("файл") || name.includes("%"))).toBe(true);
+    expect(fileNames.some((name) => name.includes("中文") || name.includes("%"))).toBe(true);
+  });
+
+  it("should parse many files directory", async () => {
+    const response = await fetch(getContainerUrl("/many-files/"));
+    expect(response.status).toBe(200);
+
+    const html = await response.text();
+    const parsed = parse(html);
+
+    expect(parsed).toBeDefined();
+    expect(parsed?.children.length).toBe(10);
+
+    const fileNames = parsed?.children.map((c) => c.name) || [];
+    expect(fileNames).toContain("file-001.txt");
+    expect(fileNames).toContain("file-010.txt");
+  });
+
+  it("should extract lastModified dates", async () => {
+    const response = await fetch(getContainerUrl());
+    const html = await response.text();
+    const parsed = parse(html);
+
+    const children = parsed?.children || [];
+
+    // F2 format should include lastModified dates
+    const filesWithDates = children.filter((c) => c.lastModified);
+    expect(filesWithDates.length).toBeGreaterThan(0);
+
+    // Dates should be reasonable (within last hour)
+    const now = Date.now();
+    const oneHourAgo = now - (60 * 60 * 1000);
+
+    filesWithDates.forEach((file) => {
+      expect(file.lastModified).toBeGreaterThan(oneHourAgo);
+      expect(file.lastModified).toBeLessThanOrEqual(now);
+    });
+  });
+
+  it("should differentiate between files and directories", async () => {
+    const response = await fetch(getContainerUrl());
+    const html = await response.text();
+    const parsed = parse(html);
+
+    const children = parsed?.children || [];
+    const files = children.filter((c) => c.type === "file");
+    const directories = children.filter((c) => c.type === "directory");
+
+    expect(files.length).toBeGreaterThan(0);
+    expect(directories.length).toBeGreaterThan(0);
+
+    // Check specific types
+    expect(files.some((f) => f.name === "ReadMe.txt")).toBe(true);
+    expect(directories.some((d) => d.name === "nested")).toBe(true);
+
+    // Directories should have children array
+    directories.forEach((dir) => {
+      expect(dir).toHaveProperty("children");
+      expect(Array.isArray((dir as any).children)).toBe(true);
+    });
+
+    // Files should not have children property
+    files.forEach((file) => {
+      expect(file).not.toHaveProperty("children");
+    });
+  });
+});

--- a/test/integrations/apache-default-config.integration.test.ts
+++ b/test/integrations/apache-default-config.integration.test.ts
@@ -1,0 +1,42 @@
+import type { StartedTestContainer } from "testcontainers";
+import { GenericContainer } from "testcontainers";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+// eslint-disable-next-line test/prefer-lowercase-title
+describe("Apache Integration Test (Default Config)", () => {
+  let apacheContainer: StartedTestContainer;
+
+  beforeAll(async () => {
+    apacheContainer = await new GenericContainer("httpd:2.4-alpine")
+      .withExposedPorts(80)
+      .start();
+  });
+
+  afterAll(async () => {
+    await apacheContainer.stop();
+  });
+
+  it("should parse Apache's default directory listing", async () => {
+    const port = apacheContainer.getMappedPort(80);
+    const host = apacheContainer.getHost();
+
+    const url = `http://${host}:${port}/`;
+    const response = await fetch(url);
+    const html = await response.text();
+
+    expect(response.ok).toBe(true);
+    // eslint-disable-next-line no-console
+    console.log(html);
+
+    // const entry = parse(html);
+
+    // expect(entry).toBeDefined();
+    // expect(entry?.type).toBe("directory");
+    // expect(entry?.path).toBe("/");
+    // expect(entry?.children.length).toBeGreaterThan(0);
+
+    // // Check if the format is inferred correctly
+    // const format = inferFormat(html);
+    // expect(format).toBe("F0"); // Default Apache format
+  });
+});

--- a/test/integrations/apache-fancy-config.integration.test.ts
+++ b/test/integrations/apache-fancy-config.integration.test.ts
@@ -26,8 +26,21 @@ describe("Apache Integration Test (Fancy Config)", async () => {
   });
 
   beforeAll(async () => {
+    const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
     apacheContainer = await new GenericContainer("httpd:2.4-alpine")
       .withExposedPorts(80)
+      .withCommand([
+        "sh",
+        "-c",
+        `apk add --no-cache tzdata && `
+        + `ln -snf /usr/share/zoneinfo/${timezone} /etc/localtime && `
+        + `echo "${timezone}" > /etc/timezone && `
+        + `exec httpd-foreground`,
+      ])
+      .withEnvironment({
+        TZ: timezone,
+      })
       .withBindMounts([
         {
           source: path.resolve("./test/configs/apache-fancy.conf"),

--- a/test/integrations/apache-fancy-config.integration.test.ts
+++ b/test/integrations/apache-fancy-config.integration.test.ts
@@ -1,0 +1,160 @@
+import type { StartedTestContainer } from "testcontainers";
+import path from "node:path";
+import { GenericContainer } from "testcontainers";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  testdir,
+} from "vitest-testdirs";
+import { inferFormat, parse } from "../../src";
+
+// eslint-disable-next-line test/prefer-lowercase-title
+describe("Apache Integration Test (Fancy Config)", async () => {
+  let apacheContainer: StartedTestContainer;
+  const testdirPath = await testdir({
+    "ReadMe.txt": `This is a test directory for Apache integration tests.`,
+    "hello.txt": `Hello, world!`,
+    "file with spaces.txt": `File with spaces in name`,
+    "file-with-dashes.css": `/* CSS file */`,
+    "file_with_underscores.js": `// JavaScript file`,
+    "UPPERCASE-FILE.XML": `<?xml version='1.0'?>`,
+    "nested": {
+      "nestedFile.txt": `This is a nested file.`,
+      "subdir": {
+        "subdirFile.txt": `This is a file in a subdirectory.`,
+      },
+    },
+  });
+
+  beforeAll(async () => {
+    apacheContainer = await new GenericContainer("httpd:2.4-alpine")
+      .withExposedPorts(80)
+      .withBindMounts([
+        {
+          source: path.resolve("./test/configs/apache-fancy.conf"),
+          target: "/usr/local/apache2/conf/httpd.conf",
+        },
+        {
+          source: testdirPath,
+          target: "/usr/local/apache2/htdocs",
+        },
+      ])
+      .start();
+  });
+
+  afterAll(async () => {
+    await apacheContainer.stop();
+  });
+
+  function getContainerUrl() {
+    const port = apacheContainer.getMappedPort(80);
+    const host = apacheContainer.getHost();
+    return `http://${host}:${port}/`;
+  }
+
+  it("infer format", async () => {
+    const response = await fetch(getContainerUrl());
+    const html = await response.text();
+
+    expect(response.ok).toBe(true);
+    const inferredFormat = inferFormat(html);
+    expect(inferredFormat).toBe("F2");
+  });
+
+  it("should parse Apache's fancy directory listing", async () => {
+    const response = await fetch(getContainerUrl());
+    const html = await response.text();
+
+    expect(response.ok).toBe(true);
+
+    const entry = parse(html);
+
+    expect(entry).toBeDefined();
+    expect(entry?.type).toBe("directory");
+    expect(entry?.path).toBe("/");
+    expect(entry?.children).toBeDefined();
+
+    const children = entry?.children || [];
+    expect(children.length).toBeGreaterThan(0);
+
+    expect(children.some((child) => child.path === "ReadMe.txt")).toBe(true);
+    expect(children.some((child) => child.path === "hello.txt")).toBe(true);
+    expect(children.some((child) => child.path === "nested/")).toBe(true);
+  });
+
+  it("should handle files with special characters", async () => {
+    const response = await fetch(getContainerUrl());
+    const html = await response.text();
+    const parsed = parse(html);
+
+    const children = parsed?.children || [];
+    const fileNames = children.map((c) => c.name);
+
+    expect(fileNames).toContain("file with spaces.txt");
+    expect(fileNames).toContain("file-with-dashes.css");
+    expect(fileNames).toContain("file_with_underscores.js");
+    expect(fileNames).toContain("UPPERCASE-FILE.XML");
+  });
+
+  it("should include lastModified dates in fancy format", async () => {
+    const response = await fetch(getContainerUrl());
+    const html = await response.text();
+    const parsed = parse(html);
+
+    const children = parsed?.children || [];
+
+    // F2 format should include lastModified dates
+    const filesWithDates = children.filter((c) => c.lastModified);
+    expect(filesWithDates.length).toBeGreaterThan(0);
+
+    // Dates should be reasonable (within last hour)
+    const now = Date.now();
+    const oneHourAgo = now - (60 * 60 * 1000);
+
+    filesWithDates.forEach((file) => {
+      expect(file.lastModified).toBeGreaterThan(oneHourAgo);
+      expect(file.lastModified).toBeLessThanOrEqual(now);
+    });
+  });
+
+  it("should differentiate between files and directories", async () => {
+    const response = await fetch(getContainerUrl());
+    const html = await response.text();
+    const parsed = parse(html);
+
+    const children = parsed?.children || [];
+    const files = children.filter((c) => c.type === "file");
+    const directories = children.filter((c) => c.type === "directory");
+
+    expect(files.length).toBeGreaterThan(0);
+    expect(directories.length).toBeGreaterThan(0);
+
+    // Check specific types
+    expect(files.some((f) => f.name === "ReadMe.txt")).toBe(true);
+    expect(directories.some((d) => d.name === "nested")).toBe(true);
+
+    // Directories should have children array (F2 format)
+    directories.forEach((dir) => {
+      expect(dir).toHaveProperty("children");
+      expect(Array.isArray((dir as any).children)).toBe(true);
+    });
+
+    // Files should not have children property
+    files.forEach((file) => {
+      expect(file).not.toHaveProperty("children");
+    });
+  });
+
+  it("should parse HTML table format correctly", async () => {
+    const response = await fetch(getContainerUrl());
+    const html = await response.text();
+
+    // F2 format should use HTML table
+    expect(html).toContain("<table");
+    expect(html).toContain("<tr");
+    expect(html).toContain("<td");
+
+    const parsed = parse(html);
+    expect(parsed).toBeDefined();
+    expect(parsed?.children.length).toBeGreaterThan(0);
+  });
+});

--- a/test/integrations/apache-pre-config.integration.test.ts
+++ b/test/integrations/apache-pre-config.integration.test.ts
@@ -65,7 +65,6 @@ describe("Apache Integration Test (Pre Config)", async () => {
     const html = await response.text();
 
     expect(response.ok).toBe(true);
-
     const entry = parse(html);
 
     expect(entry).toBeDefined();

--- a/test/integrations/apache-pre-config.integration.test.ts
+++ b/test/integrations/apache-pre-config.integration.test.ts
@@ -1,0 +1,135 @@
+import type { StartedTestContainer } from "testcontainers";
+import path from "node:path";
+import { GenericContainer } from "testcontainers";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  testdir,
+} from "vitest-testdirs";
+import { inferFormat, parse } from "../../src";
+
+// eslint-disable-next-line test/prefer-lowercase-title
+describe("Apache Integration Test (Pre Config)", async () => {
+  let apacheContainer: StartedTestContainer;
+  const testdirPath = await testdir({
+    "ReadMe.txt": `This is a test directory for Apache integration tests.`,
+    "hello.txt": `Hello, world!`,
+    "file with spaces.txt": `File with spaces in name`,
+    "file-with-dashes.css": `/* CSS file */`,
+    "file_with_underscores.js": `// JavaScript file`,
+    "UPPERCASE-FILE.XML": `<?xml version='1.0'?>`,
+    "nested": {
+      "nestedFile.txt": `This is a nested file.`,
+      "subdir": {
+        "subdirFile.txt": `This is a file in a subdirectory.`,
+      },
+    },
+  });
+
+  beforeAll(async () => {
+    apacheContainer = await new GenericContainer("httpd:2.4-alpine")
+      .withExposedPorts(80)
+      .withBindMounts([
+        {
+          source: path.resolve("./test/configs/apache-pre.conf"),
+          target: "/usr/local/apache2/conf/httpd.conf",
+        },
+        {
+          source: testdirPath,
+          target: "/usr/local/apache2/htdocs",
+        },
+      ])
+      .start();
+  });
+
+  afterAll(async () => {
+    await apacheContainer.stop();
+  });
+
+  function getContainerUrl() {
+    const port = apacheContainer.getMappedPort(80);
+    const host = apacheContainer.getHost();
+    return `http://${host}:${port}/`;
+  }
+
+  it("infer format", async () => {
+    const response = await fetch(getContainerUrl());
+    const html = await response.text();
+
+    expect(response.ok).toBe(true);
+    const inferredFormat = inferFormat(html);
+    expect(inferredFormat).toBe("F1");
+  });
+
+  it("should parse Apache's pre-formatted directory listing", async () => {
+    const response = await fetch(getContainerUrl());
+    const html = await response.text();
+
+    expect(response.ok).toBe(true);
+
+    const entry = parse(html);
+
+    expect(entry).toBeDefined();
+    expect(entry?.type).toBe("directory");
+    expect(entry?.path).toBe("/");
+    expect(entry?.children).toBeDefined();
+
+    const children = entry?.children || [];
+    expect(children.length).toBeGreaterThan(0);
+
+    expect(children.some((child) => child.path === "ReadMe.txt")).toBe(true);
+    expect(children.some((child) => child.path === "hello.txt")).toBe(true);
+    expect(children.some((child) => child.path === "nested/")).toBe(true);
+  });
+
+  it("should handle files with special characters", async () => {
+    const response = await fetch(getContainerUrl());
+    const html = await response.text();
+    const parsed = parse(html);
+
+    const children = parsed?.children || [];
+    const fileNames = children.map((c) => c.name);
+
+    expect(fileNames).toContain("file with spaces.txt");
+    expect(fileNames).toContain("file-with-dashes.css");
+    expect(fileNames).toContain("file_with_underscores.js");
+    expect(fileNames).toContain("UPPERCASE-FILE.XML");
+  });
+
+  it("should include lastModified dates in pre format", async () => {
+    const response = await fetch(getContainerUrl());
+    const html = await response.text();
+    const parsed = parse(html);
+
+    const children = parsed?.children || [];
+
+    // F1 format should include lastModified dates
+    const filesWithDates = children.filter((c) => c.lastModified);
+    expect(filesWithDates.length).toBeGreaterThan(0);
+
+    // Dates should be reasonable (within last hour)
+    const now = Date.now();
+    const oneHourAgo = now - (60 * 60 * 1000);
+
+    filesWithDates.forEach((file) => {
+      expect(file.lastModified).toBeGreaterThan(oneHourAgo);
+      expect(file.lastModified).toBeLessThanOrEqual(now);
+    });
+  });
+
+  it("should differentiate between files and directories", async () => {
+    const response = await fetch(getContainerUrl());
+    const html = await response.text();
+    const parsed = parse(html);
+
+    const children = parsed?.children || [];
+    const files = children.filter((c) => c.type === "file");
+    const directories = children.filter((c) => c.type === "directory");
+
+    expect(files.length).toBeGreaterThan(0);
+    expect(directories.length).toBeGreaterThan(0);
+
+    // Check specific types
+    expect(files.some((f) => f.name === "ReadMe.txt")).toBe(true);
+    expect(directories.some((d) => d.name === "nested")).toBe(true);
+  });
+});

--- a/test/integrations/apache-pre-config.integration.test.ts
+++ b/test/integrations/apache-pre-config.integration.test.ts
@@ -26,8 +26,21 @@ describe("Apache Integration Test (Pre Config)", async () => {
   });
 
   beforeAll(async () => {
+    const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
     apacheContainer = await new GenericContainer("httpd:2.4-alpine")
       .withExposedPorts(80)
+      .withCommand([
+        "sh",
+        "-c",
+        `apk add --no-cache tzdata && `
+        + `ln -snf /usr/share/zoneinfo/${timezone} /etc/localtime && `
+        + `echo "${timezone}" > /etc/timezone && `
+        + `exec httpd-foreground`,
+      ])
+      .withEnvironment({
+        TZ: timezone,
+      })
       .withBindMounts([
         {
           source: path.resolve("./test/configs/apache-pre.conf"),

--- a/test/integrations/apache-simple-config.integration.test.ts
+++ b/test/integrations/apache-simple-config.integration.test.ts
@@ -1,0 +1,109 @@
+import type { StartedTestContainer } from "testcontainers";
+import path from "node:path";
+import { GenericContainer } from "testcontainers";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  testdir,
+} from "vitest-testdirs";
+import { inferFormat, parse } from "../../src";
+
+// eslint-disable-next-line test/prefer-lowercase-title
+describe("Apache Integration Test (Simple Config)", async () => {
+  let apacheContainer: StartedTestContainer;
+  const testdirPath = await testdir({
+    "ReadMe.txt": `This is a test directory for Apache integration tests.`,
+    "hello.txt": `Hello, world!`,
+    "file with spaces.txt": `File with spaces in name`,
+    "file-with-dashes.css": `/* CSS file */`,
+    "file_with_underscores.js": `// JavaScript file`,
+    "UPPERCASE-FILE.XML": `<?xml version='1.0'?>`,
+    "nested": {
+      "nestedFile.txt": `This is a nested file.`,
+      "subdir": {
+        "subdirFile.txt": `This is a file in a subdirectory.`,
+      },
+    },
+  });
+
+  beforeAll(async () => {
+    apacheContainer = await new GenericContainer("httpd:2.4-alpine")
+      .withExposedPorts(80)
+      .withBindMounts([
+        {
+          source: path.resolve("./test/configs/apache-simple.conf"),
+          target: "/usr/local/apache2/conf/httpd.conf",
+        },
+        {
+          source: testdirPath,
+          target: "/usr/local/apache2/htdocs",
+        },
+      ])
+      .start();
+  });
+
+  afterAll(async () => {
+    await apacheContainer.stop();
+  });
+
+  function getContainerUrl() {
+    const port = apacheContainer.getMappedPort(80);
+    const host = apacheContainer.getHost();
+    return `http://${host}:${port}/`;
+  }
+
+  it("infer format", async () => {
+    const response = await fetch(getContainerUrl());
+    const html = await response.text();
+
+    expect(response.ok).toBe(true);
+    const inferredFormat = inferFormat(html);
+    expect(inferredFormat).toBe("F0");
+  });
+
+  it("should parse Apache's simple directory listing", async () => {
+    const response = await fetch(getContainerUrl());
+    const html = await response.text();
+
+    expect(response.ok).toBe(true);
+
+    const entry = parse(html);
+
+    expect(entry).toBeDefined();
+    expect(entry?.type).toBe("directory");
+    expect(entry?.path).toBe("/");
+    expect(entry?.children).toBeDefined();
+
+    const children = entry?.children || [];
+    expect(children.length).toBeGreaterThan(0);
+
+    expect(children.some((child) => child.path === "ReadMe.txt")).toBe(true);
+    expect(children.some((child) => child.path === "hello.txt")).toBe(true);
+    expect(children.some((child) => child.path === "nested/")).toBe(true);
+  });
+
+  it("should handle files with special characters", async () => {
+    const response = await fetch(getContainerUrl());
+    const html = await response.text();
+    const parsed = parse(html);
+
+    const children = parsed?.children || [];
+    const fileNames = children.map((c) => c.name);
+
+    expect(fileNames).toContain("file with spaces.txt");
+    expect(fileNames).toContain("file-with-dashes.css");
+    expect(fileNames).toContain("file_with_underscores.js");
+    expect(fileNames).toContain("UPPERCASE-FILE.XML");
+  });
+
+  it("should not include lastModified dates in simple format", async () => {
+    const response = await fetch(getContainerUrl());
+    const html = await response.text();
+    const parsed = parse(html);
+
+    const children = parsed?.children || [];
+
+    // F0 format should not include lastModified dates
+    const filesWithDates = children.filter((c) => c.lastModified);
+    expect(filesWithDates.length).toBe(0);
+  });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
	- Added multiple new integration test suites to verify Apache HTTP Server directory listings with default, simple, pre-formatted, fancy, and custom configurations using containerized environments.
	- Enhanced existing tests to improve validation of directory listing parsing, including handling of special characters, Unicode filenames, and last modified timestamps.
- **Chores**
	- Updated development dependencies to include "testcontainers" and "vitest-testdirs" for improved testing capabilities.
	- Fixed a typographical error in the continuous integration workflow to ensure proper node setup.
	- Updated ignore rules to exclude `.vitest-testdirs` instead of `httpd`.
- **Bug Fixes**
	- Corrected expected file name parsing in tests to properly handle special characters and encoding.
- **Refactor**
	- Simplified and unified directory listing format detection and parsing logic for improved clarity and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->