### PR TITLE
refactor: cleanup structure for v2 release

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,16 +13,9 @@ export interface DirectoryEntry {
   name: string;
   path: string;
   lastModified?: number;
-  children: Entry[];
 }
 
 export type Entry = FileEntry | DirectoryEntry;
-
-export interface RootEntry {
-  type: "directory";
-  path: string;
-  children: Entry[];
-}
 
 export type AutoIndexFormat = "F0" | "F1" | "F2";
 
@@ -31,28 +24,22 @@ export type AutoIndexFormat = "F0" | "F1" | "F2";
  *
  * @param {string} html - The HTML content of the auto-indexed directory page to parse
  * @param {AutoIndexFormat?} format - Optional format specification of the auto-index page (will be inferred if not provided)
- * @returns {RootEntry | undefined} A RootEntry object representing the parsed directory structure, or null if parsing fails
+ * @returns {Entry[]} An array of entries representing the parsed directory structure, or null if parsing fails
  *
  * @example
  * ```ts
  * const html = await fetch('http://example.com/files/').then(res => res.text());
- * const root = parse(html);
- * console.log(root.path); // '/files/'
- * console.log(root.children); // Array of file and directory entries
+ * const result = parse(html);
+ * console.log(result); // Array of file and directory entries
  * ```
  */
-export function parse(html: string, format?: AutoIndexFormat): RootEntry | null {
+export function parse(html: string, format?: AutoIndexFormat): Entry[] {
   const root = __parse(html);
 
-  if (!root) {
-    return null;
-  }
-
-  // extract title and root path
-  const titleText = root.querySelector("title")?.text || "";
-  const rootPath = titleText.split("Index of ")[1] ?? "/";
-
   let entries: Entry[] = [];
+  if (!root) {
+    return entries;
+  }
 
   if (!format) {
     format = inferFormat(root);
@@ -70,11 +57,7 @@ export function parse(html: string, format?: AutoIndexFormat): RootEntry | null 
     entries = parseF2(root);
   }
 
-  return {
-    type: "directory",
-    path: rootPath,
-    children: entries,
-  };
+  return entries;
 }
 
 /**
@@ -176,7 +159,6 @@ function parseF0(html: HTMLElement): Entry[] {
         name: name.slice(0, -1),
         path,
         lastModified: undefined,
-        children: [],
       });
     } else {
       entries.push({
@@ -234,7 +216,6 @@ function parseF1(html: HTMLElement): Entry[] {
         name: name.slice(0, -1),
         path: href,
         lastModified,
-        children: [],
       });
     } else {
       entries.push({
@@ -337,7 +318,6 @@ function parseF2(html: HTMLElement): Entry[] {
         name: name.slice(0, -1),
         path: href,
         lastModified,
-        children: [],
       });
     } else {
       entries.push({

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,7 @@ export type AutoIndexFormat = "F0" | "F1" | "F2";
  *
  * @param {string} html - The HTML content of the auto-indexed directory page to parse
  * @param {AutoIndexFormat?} format - Optional format specification of the auto-index page (will be inferred if not provided)
- * @returns {Entry[]} An array of entries representing the parsed directory structure, or null if parsing fails
+ * @returns {Entry[]} An array of entries representing the parsed directory structure, or empty array if parsing fails
  *
  * @example
  * ```ts

--- a/src/traverse.ts
+++ b/src/traverse.ts
@@ -73,7 +73,7 @@ export async function traverse(rootUrl: string, options?: TraverseOptions): Prom
 
         return {
           ...entry,
-          children: child || [],
+          children: child,
         };
       }),
     );

--- a/test/f0.test.ts
+++ b/test/f0.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from "node:fs";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { inferFormat, parse } from "../src";
+import { traverse } from "../src/traverse";
 import { createFixture } from "./__utils";
 
 const fixture = createFixture("F0");
@@ -140,5 +141,43 @@ describe("F0", () => {
       "many-files/",
       "normal-file.txt",
     ]);
+  });
+
+  it("traverse directory structure", async () => {
+    const rootHtml = readFileSync(fixture("directory.html"), "utf-8");
+    const nestedHtml = readFileSync(fixture("special-files.html"), "utf-8");
+
+    // Mock fetch to return our test fixtures
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(rootHtml),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(nestedHtml),
+      });
+
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await traverse("http://example.com/test/", { format: "F0" });
+
+    expect(result).toBeDefined();
+    expect(result).toHaveLength(6);
+
+    // Find the level2 directory entry
+    const level2Dir = result.find((entry) => entry.name === "level2");
+    expect(level2Dir).toBeDefined();
+    expect(level2Dir?.type).toBe("directory");
+    expect(level2Dir?.children).toBeDefined();
+    expect(level2Dir?.children).toHaveLength(20);
+
+    // Verify some of the nested entries
+    const nestedFile = level2Dir?.children?.find((entry) => entry.name === "ReadMe.txt");
+    expect(nestedFile).toBeDefined();
+    expect(nestedFile?.type).toBe("file");
+
+    vi.unstubAllGlobals();
   });
 });

--- a/test/f0.test.ts
+++ b/test/f0.test.ts
@@ -18,11 +18,11 @@ describe("F0", () => {
   it("unicode.org's public directory listing", () => {
     const html = readFileSync(fixture("unicode-org.html"), "utf-8");
 
-    const entry = parse(html, "F0");
+    const entries = parse(html, "F0");
 
-    expect(entry).toBeDefined();
+    expect(entries).toBeDefined();
 
-    const paths = entry?.children.map((entry) => entry.path);
+    const paths = entries.map((entry) => entry.path);
 
     expect(paths).toStrictEqual([
       "1.1-Update/",
@@ -77,7 +77,7 @@ describe("F0", () => {
       "zipped/",
     ]);
 
-    const files = entry?.children.filter((entry) => entry.type === "file");
+    const files = entries.filter((entry) => entry.type === "file");
 
     expect(files).toHaveLength(1);
     expect(files).toStrictEqual([
@@ -93,11 +93,11 @@ describe("F0", () => {
   it("parse directory", () => {
     const html = readFileSync(fixture("directory.html"), "utf-8");
 
-    const entry = parse(html, "F0");
+    const entries = parse(html, "F0");
 
-    expect(entry).toBeDefined();
+    expect(entries).toBeDefined();
 
-    const paths = entry?.children.map((entry) => entry.path);
+    const paths = entries.map((entry) => entry.path);
 
     expect(paths).toStrictEqual([
       "file%20with%20spaces.txt",
@@ -112,11 +112,11 @@ describe("F0", () => {
   it("parse special files", () => {
     const html = readFileSync(fixture("special-files.html"), "utf-8");
 
-    const entry = parse(html, "F0");
+    const entries = parse(html, "F0");
 
-    expect(entry).toBeDefined();
+    expect(entries).toBeDefined();
 
-    const paths = entry?.children.map((entry) => entry.path);
+    const paths = entries.map((entry) => entry.path);
 
     expect(paths).toStrictEqual([
       "ReadMe.txt",

--- a/test/f1.test.ts
+++ b/test/f1.test.ts
@@ -18,11 +18,11 @@ describe("F1", () => {
   it("unicode.org's public directory listing", () => {
     const html = readFileSync(fixture("unicode-org.html"), "utf-8");
 
-    const entry = parse(html, "F1");
+    const entries = parse(html, "F1");
 
-    expect(entry).toBeDefined();
+    expect(entries).toBeDefined();
 
-    const paths = entry?.children.map((entry) => entry.path);
+    const paths = entries.map((entry) => entry.path);
 
     expect(paths).toStrictEqual([
       "1.1-Update/",
@@ -77,7 +77,7 @@ describe("F1", () => {
       "zipped/",
     ]);
 
-    const files = entry?.children.filter((entry) => entry.type === "file");
+    const files = entries.filter((entry) => entry.type === "file");
 
     expect(files).toHaveLength(1);
     expect(files).toStrictEqual([
@@ -93,11 +93,11 @@ describe("F1", () => {
   it("parse directory", () => {
     const html = readFileSync(fixture("directory.html"), "utf-8");
 
-    const entry = parse(html, "F1");
+    const entries = parse(html, "F1");
 
-    expect(entry).toBeDefined();
+    expect(entries).toBeDefined();
 
-    const paths = entry?.children.map((entry) => entry.path);
+    const paths = entries.map((entry) => entry.path);
 
     expect(paths).toStrictEqual([
       "file%20with%20spaces.txt",
@@ -112,11 +112,11 @@ describe("F1", () => {
   it("parse special files", () => {
     const html = readFileSync(fixture("special-files.html"), "utf-8");
 
-    const entry = parse(html, "F1");
+    const entries = parse(html, "F1");
 
-    expect(entry).toBeDefined();
+    expect(entries).toBeDefined();
 
-    const paths = entry?.children.map((entry) => entry.path);
+    const paths = entries.map((entry) => entry.path);
 
     expect(paths).toStrictEqual([
       "ReadMe.txt",

--- a/test/f1.test.ts
+++ b/test/f1.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from "node:fs";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { inferFormat, parse } from "../src";
+import { traverse } from "../src/traverse";
 import { createFixture } from "./__utils";
 
 const fixture = createFixture("F1");
@@ -140,5 +141,42 @@ describe("F1", () => {
       "many-files/",
       "normal-file.txt",
     ]);
+  });
+
+  it("traverse directory structure", async () => {
+    const rootHtml = readFileSync(fixture("directory.html"), "utf-8");
+    const nestedHtml = readFileSync(fixture("special-files.html"), "utf-8");
+
+    // Mock fetch to return our test fixtures
+    const mockFetch = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(rootHtml),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(nestedHtml),
+      });
+
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await traverse("http://example.com/test/", { format: "F1" });
+
+    expect(result).toBeDefined();
+    expect(result).toHaveLength(6);
+
+    // Find the level2 directory entry
+    const level2Dir = result.find((entry) => entry.name === "level2");
+    expect(level2Dir).toBeDefined();
+    expect(level2Dir?.type).toBe("directory");
+    expect(level2Dir?.children).toBeDefined();
+    expect(level2Dir?.children).toHaveLength(20);
+
+    // Verify some of the nested entries
+    const nestedFile = level2Dir?.children?.find((entry) => entry.name === "ReadMe.txt");
+    expect(nestedFile).toBeDefined();
+    expect(nestedFile?.type).toBe("file");
+
+    vi.unstubAllGlobals();
   });
 });

--- a/test/f2.test.ts
+++ b/test/f2.test.ts
@@ -18,11 +18,11 @@ describe("F2", () => {
   it("unicode.org's public directory listing", () => {
     const html = readFileSync(fixture("unicode-org.html"), "utf-8");
 
-    const entry = parse(html, "F2");
+    const entries = parse(html, "F2");
 
-    expect(entry).toBeDefined();
+    expect(entries).toBeDefined();
 
-    const paths = entry?.children.map((entry) => entry.path);
+    const paths = entries.map((entry) => entry.path);
 
     expect(paths).toStrictEqual([
       "1.1-Update/",
@@ -77,7 +77,7 @@ describe("F2", () => {
       "zipped/",
     ]);
 
-    const files = entry?.children.filter((entry) => entry.type === "file");
+    const files = entries.filter((entry) => entry.type === "file");
 
     expect(files).toHaveLength(1);
     expect(files).toStrictEqual([
@@ -93,11 +93,11 @@ describe("F2", () => {
   it("parse directory", () => {
     const html = readFileSync(fixture("directory.html"), "utf-8");
 
-    const entry = parse(html, "F2");
+    const entries = parse(html, "F2");
 
-    expect(entry).toBeDefined();
+    expect(entries).toBeDefined();
 
-    const paths = entry?.children.map((entry) => entry.path);
+    const paths = entries.map((entry) => entry.path);
 
     expect(paths).toStrictEqual([
       "file%20with%20spaces.txt",
@@ -112,11 +112,11 @@ describe("F2", () => {
   it("parse special files", () => {
     const html = readFileSync(fixture("special-files.html"), "utf-8");
 
-    const entry = parse(html, "F2");
+    const entries = parse(html, "F2");
 
-    expect(entry).toBeDefined();
+    expect(entries).toBeDefined();
 
-    const paths = entry?.children.map((entry) => entry.path);
+    const paths = entries.map((entry) => entry.path);
 
     expect(paths).toStrictEqual([
       "ReadMe.txt",

--- a/test/integrations/apache-custom-config.integration.test.ts
+++ b/test/integrations/apache-custom-config.integration.test.ts
@@ -199,16 +199,5 @@ describe("Apache Custom Config Integration Test", async () => {
     // Check specific types
     expect(files.some((f) => f.name === "ReadMe.txt")).toBe(true);
     expect(directories.some((d) => d.name === "nested")).toBe(true);
-
-    // Directories should have children array
-    directories.forEach((dir) => {
-      expect(dir).toHaveProperty("children");
-      expect(Array.isArray((dir as any).children)).toBe(true);
-    });
-
-    // Files should not have children property
-    files.forEach((file) => {
-      expect(file).not.toHaveProperty("children");
-    });
   });
 });

--- a/test/integrations/apache-custom-config.integration.test.ts
+++ b/test/integrations/apache-custom-config.integration.test.ts
@@ -94,18 +94,13 @@ describe("Apache Custom Config Integration Test", async () => {
   it("should parse root directory correctly", async () => {
     const response = await fetch(getContainerUrl());
     const html = await response.text();
-    const parsed = parse(html);
+    const entries = parse(html);
 
-    expect(parsed).toBeDefined();
-    expect(parsed?.type).toBe("directory");
-    expect(parsed?.path).toBe("/");
-    expect(parsed?.children).toBeDefined();
-
-    const children = parsed?.children || [];
-    expect(children.length).toBeGreaterThan(5);
+    expect(entries).toBeDefined();
+    expect(entries.length).toBeGreaterThan(5);
 
     // Check for expected files
-    const fileNames = children.map((child) => child.name);
+    const fileNames = entries.map((child) => child.name);
     expect(fileNames).toContain("ReadMe.txt");
     expect(fileNames).toContain("normal-file.html");
     expect(fileNames).toContain("nested");
@@ -115,9 +110,9 @@ describe("Apache Custom Config Integration Test", async () => {
   it("should handle files with special characters", async () => {
     const response = await fetch(getContainerUrl());
     const html = await response.text();
-    const parsed = parse(html);
+    const entries = parse(html);
 
-    const fileNames = parsed?.children.map((c) => c.name) || [];
+    const fileNames = entries.map((c) => c.name);
     expect(fileNames).toContain("file with spaces.txt");
     expect(fileNames).toContain("file-with-dashes.css");
     expect(fileNames).toContain("file_with_underscores.js");
@@ -131,16 +126,12 @@ describe("Apache Custom Config Integration Test", async () => {
     expect(response.status).toBe(200);
 
     const html = await response.text();
-    const parsed = parse(html);
+    const entries = parse(html);
 
-    expect(parsed).toBeDefined();
-    expect(parsed?.type).toBe("directory");
-    expect(parsed?.path).toBe("/nested");
+    expect(entries).toBeDefined();
+    expect(entries.length).toBeGreaterThan(0);
 
-    const children = parsed?.children || [];
-    expect(children.length).toBeGreaterThan(0);
-
-    const childNames = children.map((c) => c.name);
+    const childNames = entries.map((c) => c.name);
     expect(childNames).toContain("nestedFile.txt");
     expect(childNames).toContain("special chars");
     expect(childNames).toContain("deep");
@@ -151,10 +142,9 @@ describe("Apache Custom Config Integration Test", async () => {
     expect(response.status).toBe(200);
 
     const html = await response.text();
-    const parsed = parse(html);
+    const entries = parse(html);
 
-    const children = parsed?.children || [];
-    const fileNames = children.map((c) => c.name);
+    const fileNames = entries.map((c) => c.name);
 
     // Unicode filenames should be parsed correctly
     expect(fileNames.some((name) => name.includes("файл") || name.includes("%"))).toBe(true);
@@ -166,12 +156,12 @@ describe("Apache Custom Config Integration Test", async () => {
     expect(response.status).toBe(200);
 
     const html = await response.text();
-    const parsed = parse(html);
+    const entries = parse(html);
 
-    expect(parsed).toBeDefined();
-    expect(parsed?.children.length).toBe(10);
+    expect(entries).toBeDefined();
+    expect(entries.length).toBe(10);
 
-    const fileNames = parsed?.children.map((c) => c.name) || [];
+    const fileNames = entries.map((c) => c.name);
     expect(fileNames).toContain("file-001.txt");
     expect(fileNames).toContain("file-010.txt");
   });
@@ -179,12 +169,10 @@ describe("Apache Custom Config Integration Test", async () => {
   it("should extract lastModified dates", async () => {
     const response = await fetch(getContainerUrl());
     const html = await response.text();
-    const parsed = parse(html);
-
-    const children = parsed?.children || [];
+    const entries = parse(html);
 
     // F2 format should include lastModified dates
-    const filesWithDates = children.filter((c) => c.lastModified);
+    const filesWithDates = entries.filter((c) => c.lastModified);
     expect(filesWithDates.length).toBeGreaterThan(0);
 
     // Dates should be reasonable (within last hour)
@@ -200,11 +188,10 @@ describe("Apache Custom Config Integration Test", async () => {
   it("should differentiate between files and directories", async () => {
     const response = await fetch(getContainerUrl());
     const html = await response.text();
-    const parsed = parse(html);
+    const entries = parse(html);
 
-    const children = parsed?.children || [];
-    const files = children.filter((c) => c.type === "file");
-    const directories = children.filter((c) => c.type === "directory");
+    const files = entries.filter((c) => c.type === "file");
+    const directories = entries.filter((c) => c.type === "directory");
 
     expect(files.length).toBeGreaterThan(0);
     expect(directories.length).toBeGreaterThan(0);

--- a/test/integrations/apache-default-config.integration.test.ts
+++ b/test/integrations/apache-default-config.integration.test.ts
@@ -57,17 +57,12 @@ describe("Apache Integration Test (Default Config)", async () => {
 
     expect(response.ok).toBe(true);
 
-    const entry = parse(html);
+    const entries = parse(html);
 
-    expect(entry).toBeDefined();
-    expect(entry?.type).toBe("directory");
-    expect(entry?.path).toBe("/");
-    expect(entry?.children).toBeDefined();
+    expect(entries).toBeDefined();
+    expect(entries.length).toBeGreaterThan(0);
 
-    const children = entry?.children || [];
-    expect(children.length).toBeGreaterThan(0);
-
-    expect(children.some((child) => child.path === "ReadMe.txt")).toBe(true);
-    expect(children.some((child) => child.path === "hello.txt")).toBe(true);
+    expect(entries.some((child) => child.path === "ReadMe.txt")).toBe(true);
+    expect(entries.some((child) => child.path === "hello.txt")).toBe(true);
   });
 });

--- a/test/integrations/apache-fancy-config.integration.test.ts
+++ b/test/integrations/apache-fancy-config.integration.test.ts
@@ -79,28 +79,22 @@ describe("Apache Integration Test (Fancy Config)", async () => {
 
     expect(response.ok).toBe(true);
 
-    const entry = parse(html);
+    const entries = parse(html);
 
-    expect(entry).toBeDefined();
-    expect(entry?.type).toBe("directory");
-    expect(entry?.path).toBe("/");
-    expect(entry?.children).toBeDefined();
+    expect(entries).toBeDefined();
+    expect(entries.length).toBeGreaterThan(0);
 
-    const children = entry?.children || [];
-    expect(children.length).toBeGreaterThan(0);
-
-    expect(children.some((child) => child.path === "ReadMe.txt")).toBe(true);
-    expect(children.some((child) => child.path === "hello.txt")).toBe(true);
-    expect(children.some((child) => child.path === "nested/")).toBe(true);
+    expect(entries.some((child) => child.path === "ReadMe.txt")).toBe(true);
+    expect(entries.some((child) => child.path === "hello.txt")).toBe(true);
+    expect(entries.some((child) => child.path === "nested/")).toBe(true);
   });
 
   it("should handle files with special characters", async () => {
     const response = await fetch(getContainerUrl());
     const html = await response.text();
-    const parsed = parse(html);
+    const entries = parse(html);
 
-    const children = parsed?.children || [];
-    const fileNames = children.map((c) => c.name);
+    const fileNames = entries.map((c) => c.name);
 
     expect(fileNames).toContain("file with spaces.txt");
     expect(fileNames).toContain("file-with-dashes.css");
@@ -111,12 +105,10 @@ describe("Apache Integration Test (Fancy Config)", async () => {
   it("should include lastModified dates in fancy format", async () => {
     const response = await fetch(getContainerUrl());
     const html = await response.text();
-    const parsed = parse(html);
-
-    const children = parsed?.children || [];
+    const entries = parse(html);
 
     // F2 format should include lastModified dates
-    const filesWithDates = children.filter((c) => c.lastModified);
+    const filesWithDates = entries.filter((c) => c.lastModified);
     expect(filesWithDates.length).toBeGreaterThan(0);
 
     // Dates should be reasonable (within last hour)
@@ -132,11 +124,10 @@ describe("Apache Integration Test (Fancy Config)", async () => {
   it("should differentiate between files and directories", async () => {
     const response = await fetch(getContainerUrl());
     const html = await response.text();
-    const parsed = parse(html);
+    const entries = parse(html);
 
-    const children = parsed?.children || [];
-    const files = children.filter((c) => c.type === "file");
-    const directories = children.filter((c) => c.type === "directory");
+    const files = entries.filter((c) => c.type === "file");
+    const directories = entries.filter((c) => c.type === "directory");
 
     expect(files.length).toBeGreaterThan(0);
     expect(directories.length).toBeGreaterThan(0);
@@ -166,8 +157,8 @@ describe("Apache Integration Test (Fancy Config)", async () => {
     expect(html).toContain("<tr");
     expect(html).toContain("<td");
 
-    const parsed = parse(html);
-    expect(parsed).toBeDefined();
-    expect(parsed?.children.length).toBeGreaterThan(0);
+    const entries = parse(html);
+    expect(entries).toBeDefined();
+    expect(entries.length).toBeGreaterThan(0);
   });
 });

--- a/test/integrations/apache-fancy-config.integration.test.ts
+++ b/test/integrations/apache-fancy-config.integration.test.ts
@@ -135,17 +135,6 @@ describe("Apache Integration Test (Fancy Config)", async () => {
     // Check specific types
     expect(files.some((f) => f.name === "ReadMe.txt")).toBe(true);
     expect(directories.some((d) => d.name === "nested")).toBe(true);
-
-    // Directories should have children array (F2 format)
-    directories.forEach((dir) => {
-      expect(dir).toHaveProperty("children");
-      expect(Array.isArray((dir as any).children)).toBe(true);
-    });
-
-    // Files should not have children property
-    files.forEach((file) => {
-      expect(file).not.toHaveProperty("children");
-    });
   });
 
   it("should parse HTML table format correctly", async () => {

--- a/test/integrations/apache-pre-config.integration.test.ts
+++ b/test/integrations/apache-pre-config.integration.test.ts
@@ -78,28 +78,22 @@ describe("Apache Integration Test (Pre Config)", async () => {
     const html = await response.text();
 
     expect(response.ok).toBe(true);
-    const entry = parse(html);
+    const entries = parse(html);
 
-    expect(entry).toBeDefined();
-    expect(entry?.type).toBe("directory");
-    expect(entry?.path).toBe("/");
-    expect(entry?.children).toBeDefined();
+    expect(entries).toBeDefined();
+    expect(entries.length).toBeGreaterThan(0);
 
-    const children = entry?.children || [];
-    expect(children.length).toBeGreaterThan(0);
-
-    expect(children.some((child) => child.path === "ReadMe.txt")).toBe(true);
-    expect(children.some((child) => child.path === "hello.txt")).toBe(true);
-    expect(children.some((child) => child.path === "nested/")).toBe(true);
+    expect(entries.some((child) => child.path === "ReadMe.txt")).toBe(true);
+    expect(entries.some((child) => child.path === "hello.txt")).toBe(true);
+    expect(entries.some((child) => child.path === "nested/")).toBe(true);
   });
 
   it("should handle files with special characters", async () => {
     const response = await fetch(getContainerUrl());
     const html = await response.text();
-    const parsed = parse(html);
+    const entries = parse(html);
 
-    const children = parsed?.children || [];
-    const fileNames = children.map((c) => c.name);
+    const fileNames = entries.map((c) => c.name);
 
     expect(fileNames).toContain("file with spaces.txt");
     expect(fileNames).toContain("file-with-dashes.css");
@@ -110,12 +104,10 @@ describe("Apache Integration Test (Pre Config)", async () => {
   it("should include lastModified dates in pre format", async () => {
     const response = await fetch(getContainerUrl());
     const html = await response.text();
-    const parsed = parse(html);
-
-    const children = parsed?.children || [];
+    const entries = parse(html);
 
     // F1 format should include lastModified dates
-    const filesWithDates = children.filter((c) => c.lastModified);
+    const filesWithDates = entries.filter((c) => c.lastModified);
     expect(filesWithDates.length).toBeGreaterThan(0);
 
     // Dates should be reasonable (within last hour)
@@ -131,11 +123,10 @@ describe("Apache Integration Test (Pre Config)", async () => {
   it("should differentiate between files and directories", async () => {
     const response = await fetch(getContainerUrl());
     const html = await response.text();
-    const parsed = parse(html);
+    const entries = parse(html);
 
-    const children = parsed?.children || [];
-    const files = children.filter((c) => c.type === "file");
-    const directories = children.filter((c) => c.type === "directory");
+    const files = entries.filter((c) => c.type === "file");
+    const directories = entries.filter((c) => c.type === "directory");
 
     expect(files.length).toBeGreaterThan(0);
     expect(directories.length).toBeGreaterThan(0);

--- a/test/integrations/apache-simple-config.integration.test.ts
+++ b/test/integrations/apache-simple-config.integration.test.ts
@@ -66,28 +66,22 @@ describe("Apache Integration Test (Simple Config)", async () => {
 
     expect(response.ok).toBe(true);
 
-    const entry = parse(html);
+    const entries = parse(html);
 
-    expect(entry).toBeDefined();
-    expect(entry?.type).toBe("directory");
-    expect(entry?.path).toBe("/");
-    expect(entry?.children).toBeDefined();
+    expect(entries).toBeDefined();
+    expect(entries.length).toBeGreaterThan(0);
 
-    const children = entry?.children || [];
-    expect(children.length).toBeGreaterThan(0);
-
-    expect(children.some((child) => child.path === "ReadMe.txt")).toBe(true);
-    expect(children.some((child) => child.path === "hello.txt")).toBe(true);
-    expect(children.some((child) => child.path === "nested/")).toBe(true);
+    expect(entries.some((child) => child.path === "ReadMe.txt")).toBe(true);
+    expect(entries.some((child) => child.path === "hello.txt")).toBe(true);
+    expect(entries.some((child) => child.path === "nested/")).toBe(true);
   });
 
   it("should handle files with special characters", async () => {
     const response = await fetch(getContainerUrl());
     const html = await response.text();
-    const parsed = parse(html);
+    const entries = parse(html);
 
-    const children = parsed?.children || [];
-    const fileNames = children.map((c) => c.name);
+    const fileNames = entries.map((c) => c.name);
 
     expect(fileNames).toContain("file with spaces.txt");
     expect(fileNames).toContain("file-with-dashes.css");
@@ -98,12 +92,10 @@ describe("Apache Integration Test (Simple Config)", async () => {
   it("should not include lastModified dates in simple format", async () => {
     const response = await fetch(getContainerUrl());
     const html = await response.text();
-    const parsed = parse(html);
-
-    const children = parsed?.children || [];
+    const entries = parse(html);
 
     // F0 format should not include lastModified dates
-    const filesWithDates = children.filter((c) => c.lastModified);
+    const filesWithDates = entries.filter((c) => c.lastModified);
     expect(filesWithDates.length).toBe(0);
   });
 });


### PR DESCRIPTION
This PR refactors the return types of the `parse` & `traverse` functions. This is done since the result of `parse` was a bit confusing.

Since the `RootEntry` contained some Entry which also had support for children, but was never returning any.. Only the `traverse` function was able to return nested children.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for recursively traversing directory structures and retrieving nested entries using the updated traversal functionality.

* **Refactor**
  * Simplified the directory parsing output to return a flat array of entries instead of a nested structure with children.
  * Updated all related test cases and documentation to reflect the new flat array format for parsed directory entries.

* **Bug Fixes**
  * Standardized error handling to return empty arrays instead of null values when parsing or traversal fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->