### PR TITLE
fix: handle traverse urls correctly

### DIFF
--- a/src/traverse.ts
+++ b/src/traverse.ts
@@ -69,7 +69,9 @@ export async function traverse(rootUrl: string, options?: TraverseOptions): Prom
           return entry;
         }
 
-        const childUrl = (rootUrl.endsWith("/") ? rootUrl : `${rootUrl}/`) + entry.path;
+        const childUrl = rootUrl.endsWith("/") 
+          ? rootUrl + (entry.path.startsWith("/") ? entry.path.slice(1) : entry.path)
+          : rootUrl + (entry.path.startsWith("/") ? entry.path : `/${entry.path}`);
         const child = await traverse(childUrl, options);
 
         entry.name = trimTrailingSlash(entry.name);

--- a/src/traverse.ts
+++ b/src/traverse.ts
@@ -69,7 +69,7 @@ export async function traverse(rootUrl: string, options?: TraverseOptions): Prom
           return entry;
         }
 
-        const childUrl = new URL(entry.path, rootUrl.endsWith("/") ? rootUrl : `${rootUrl}/`).href;
+        const childUrl = (rootUrl.endsWith("/") ? rootUrl : `${rootUrl}/`) + entry.path;
         const child = await traverse(childUrl, options);
 
         entry.name = trimTrailingSlash(entry.name);

--- a/src/traverse.ts
+++ b/src/traverse.ts
@@ -69,7 +69,7 @@ export async function traverse(rootUrl: string, options?: TraverseOptions): Prom
           return entry;
         }
 
-        const childUrl = rootUrl.endsWith("/") 
+        const childUrl = rootUrl.endsWith("/")
           ? rootUrl + (entry.path.startsWith("/") ? entry.path.slice(1) : entry.path)
           : rootUrl + (entry.path.startsWith("/") ? entry.path : `/${entry.path}`);
         const child = await traverse(childUrl, options);

--- a/test/f1.test.ts
+++ b/test/f1.test.ts
@@ -207,7 +207,7 @@ describe("F1", () => {
     // Entry path "/level2/" should be appended to base URL, not replace its path
     expect(mockFetch).toHaveBeenCalledWith(
       "http://example.com/public/files/level2/",
-      expect.any(Object)
+      expect.any(Object),
     );
 
     vi.unstubAllGlobals();

--- a/test/f1.test.ts
+++ b/test/f1.test.ts
@@ -179,4 +179,37 @@ describe("F1", () => {
 
     vi.unstubAllGlobals();
   });
+
+  it("traverse with entry paths having leading slash", async () => {
+    const rootHtml = readFileSync(fixture("directory.html"), "utf-8");
+    const nestedHtml = readFileSync(fixture("special-files.html"), "utf-8");
+
+    // Mock fetch to verify URL construction with leading slash paths
+    const mockFetch = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(rootHtml),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(nestedHtml),
+      });
+
+    vi.stubGlobal("fetch", mockFetch);
+
+    // Test with root URL that has a path component
+    const result = await traverse("http://example.com/public/files", { format: "F1" });
+
+    expect(result).toBeDefined();
+    expect(result).toHaveLength(6);
+
+    // Verify that the nested directory URL was constructed correctly
+    // Entry path "/level2/" should be appended to base URL, not replace its path
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://example.com/public/files/level2/",
+      expect.any(Object)
+    );
+
+    vi.unstubAllGlobals();
+  });
 });

--- a/test/f2.test.ts
+++ b/test/f2.test.ts
@@ -179,4 +179,37 @@ describe("F2", () => {
 
     vi.unstubAllGlobals();
   });
+
+  it("traverse with entry paths having leading slash", async () => {
+    const rootHtml = readFileSync(fixture("directory.html"), "utf-8");
+    const nestedHtml = readFileSync(fixture("special-files.html"), "utf-8");
+
+    // Mock fetch to verify URL construction with leading slash paths
+    const mockFetch = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(rootHtml),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(nestedHtml),
+      });
+
+    vi.stubGlobal("fetch", mockFetch);
+
+    // Test with root URL that has a path component
+    const result = await traverse("http://example.com/public/files", { format: "F2" });
+
+    expect(result).toBeDefined();
+    expect(result).toHaveLength(6);
+
+    // Verify that the nested directory URL was constructed correctly
+    // Entry path "/level2/" should be appended to base URL, not replace its path
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://example.com/public/files/level2/",
+      expect.any(Object)
+    );
+
+    vi.unstubAllGlobals();
+  });
 });

--- a/test/f2.test.ts
+++ b/test/f2.test.ts
@@ -207,7 +207,7 @@ describe("F2", () => {
     // Entry path "/level2/" should be appended to base URL, not replace its path
     expect(mockFetch).toHaveBeenCalledWith(
       "http://example.com/public/files/level2/",
-      expect.any(Object)
+      expect.any(Object),
     );
 
     vi.unstubAllGlobals();


### PR DESCRIPTION
* Implement tests to verify URL construction when entry paths have leading slashes.
* Ensure that the base URL is preserved and paths are appended correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of URL construction during directory traversal, ensuring nested paths are appended correctly.

* **Tests**
  * Added new test cases to verify correct traversal behavior when entry paths have leading slashes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->